### PR TITLE
Add Artikodin workflow

### DIFF
--- a/.github/workflows/artikodin.yaml
+++ b/.github/workflows/artikodin.yaml
@@ -1,0 +1,73 @@
+name: Artikodin pull-request handler
+
+
+on:
+  # Runs on a pull request for the main branch
+  pull_request:
+    types:
+      # Default events
+      - opened
+      - synchronize
+      - reopened
+      # But we also want to make sure a potential
+      # exception request pull request is getting
+      # closed if any was open
+      - closed
+    branch:
+      - main
+
+  # Runs on a merge group build
+  merge_group:
+    types:
+      - checks_requested
+
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  handle:
+    name: Run Artikodin handler
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Getting an app token if Artikodin is available
+        env:
+          ARTIKODIN_CONTROLLER_APP_ID: ${{ secrets.ARTIKODIN_CONTROLLER_APP_ID }}
+          ARTIKODIN_CONTROLLER_PRIVATE_KEY: ${{ secrets.ARTIKODIN_CONTROLLER_PRIVATE_KEY }}
+          ARTIKODIN_CONTENTS_APP_ID: ${{ secrets.ARTIKODIN_CONTENTS_APP_ID }}
+          ARTIKODIN_CONTENTS_PRIVATE_KEY: ${{ secrets.ARTIKODIN_CONTENTS_PRIVATE_KEY }}
+        if: ${{ env.ARTIKODIN_CONTROLLER_APP_ID != '' && env.ARTIKODIN_CONTROLLER_PRIVATE_KEY != '' && env.ARTIKODIN_CONTENTS_APP_ID != '' && env.ARTIKODIN_CONTENTS_PRIVATE_KEY != '' }}
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.ARTIKODIN_CONTENTS_APP_ID }}
+          private-key: ${{ secrets.ARTIKODIN_CONTENTS_PRIVATE_KEY }}
+          owner: temporalio
+          repositories: artikodin
+
+      - name: Checkout Artikodin
+        if: ${{ steps.app-token.outputs.token != '' }}
+        uses: actions/checkout@v4
+        with:
+          repository: temporalio/artikodin
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Synchronize authorization
+        if: ${{ steps.app-token.outputs.token != '' }}
+        uses: ./request
+        with:
+          skip-checkout: true
+          contents-app-id: ${{ secrets.ARTIKODIN_CONTENTS_APP_ID }}
+          contents-private-key: ${{ secrets.ARTIKODIN_CONTENTS_PRIVATE_KEY }}
+          controller-app-id: ${{ secrets.ARTIKODIN_CONTROLLER_APP_ID }}
+          controller-private-key: ${{ secrets.ARTIKODIN_CONTROLLER_PRIVATE_KEY }}
+          target-repository: "${{ github.repository }}"
+          target-pull-request: "${{ github.event.pull_request.number }}"
+          target-merge-group-head-ref: "${{ github.event.merge_group.head_ref }}"
+          target-git-sha: "${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}"
+          closing-pr: ${{ github.event.action == 'closed' }}


### PR DESCRIPTION
This allows to add support for Artikodin Code Freeze in all the repositories without having to individually add the workflows in each repository.

This will need to be enabled in the organization rules.
This will be a noop if the secrets are not available.