### PR TITLE
Avoid running semgrep on merge groups

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -24,7 +24,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
-    if: (github.actor != 'dependabot[bot]')
+    if: github.actor != 'dependabot[bot]' && github.event_name != 'merge_group'
     steps:
       - uses: actions/checkout@v4
       - name: Run semgrep ci


### PR DESCRIPTION
Semgrep is taking an awful amount of time when running in merge queues, this is disabling it for those cases while keeping the workflow running to fit the requirement.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Disable semgrep runs on merge queues.

## Why?
<!-- Tell your future self why have you made these changes -->
Because semgrep seems to take an awful lot of time when running on merge queues, since it reevaluates the whole code.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
