### PR TITLE
Add pull request trigger for closed trigger type

### DIFF
--- a/.github/workflows/artikodin.yaml
+++ b/.github/workflows/artikodin.yaml
@@ -19,6 +19,13 @@ on:
     branch:
       - main
 
+  # This does not work on forks, we are duplicating
+  # the 'closed' call here because it does not seem
+  # to behave as expected for `pull_request_target`.
+  pull_request:
+    types:
+      - closed
+
   # Runs on a merge group build
   merge_group:
     types:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Add `pull_request` / `closed` trigger.

## Why?
<!-- Tell your future self why have you made these changes -->

For some reason, it does not seem to trigger for `pull_request_target` right now; it might be related to merge queues only (since it seems to have closed others properly when merge queues are not involved), but it leaves exceptions requests pull requests open instead of tagging them properly and closing them.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
