### PR TITLE
Update semgrep.yml

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -24,7 +24,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
-    if: github.actor != 'dependabot[bot]' && github.event_name != 'merge_group'
+    if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions' && github.event_name != 'merge_group'
     steps:
       - uses: actions/checkout@v4
       - name: Run semgrep ci


### PR DESCRIPTION
## What was changed
Tell the Semgrep action to ignore commits from a user named github-actions.

## Why?
After chatting with Semgrep support, determined that the reason this action hangs for github actions that check the results of `terraform fmt` into a PR is because it should be excluded anyway.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
