### PR TITLE
Update require-codeowners.yml

### DIFF
--- a/.github/workflows/require-codeowners.yml
+++ b/.github/workflows/require-codeowners.yml
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repo
+      - name: Checkout branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Find doesn't return non-0 for no results, but grep does.
       - name: Check for CODEOWNERS


### PR DESCRIPTION
## What was changed
Change the variable to pull the ref I actually meant to pull.

## Why?
The `github.ref_name` was still resolving to main instead of the branch of the PR. Looking at [the checkout action docs](https://github.com/temporalio/public-actions/pull/14), this is the way I have to pull the correct reference. So it's still currently failing on PRs that are meant to fix this check, which is not desired behavior.
