### PR TITLE
Don't run the check on commits by bots

### DIFF
--- a/.github/workflows/require-codeowners.yml
+++ b/.github/workflows/require-codeowners.yml
@@ -31,8 +31,8 @@ concurrency:
 jobs:
   check:
     name: Check for CODEOWNERS
-
     runs-on: ubuntu-latest
+    if: ${{ !endsWith(github.actor, '[bot]') }}
 
     steps:
       - name: Checkout branch

--- a/.github/workflows/require-codeowners.yml
+++ b/.github/workflows/require-codeowners.yml
@@ -32,7 +32,7 @@ jobs:
   check:
     name: Check for CODEOWNERS
     runs-on: ubuntu-latest
-    if: ${{ !endsWith(github.actor, '[bot]') }}
+    if: github.event.pull_request.draft == false && ${{ !endsWith(github.actor, '[bot]') }}
 
     steps:
       - name: Checkout branch


### PR DESCRIPTION
## What was changed
Don't run the CODEOWNERS check on commits from bots or drafts.

## Why?
Due to an internal control it Github, it refuses to actually run and return a status on this workflow when triggered by a bot, because it wants to prevent infinite loops.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
