### PR TITLE
Fix workflow syntax warning and update checkout to Node.js 24

### DIFF
--- a/.github/workflows/require-codeowners.yml
+++ b/.github/workflows/require-codeowners.yml
@@ -32,11 +32,11 @@ jobs:
   check:
     name: Check for CODEOWNERS
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false && ${{ !endsWith(github.actor, '[bot]') }}
+    if: ${{ github.event.pull_request.draft == false && !endsWith(github.actor, '[bot]') }}
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 


### PR DESCRIPTION
## What was changed
Wrap the entire `if` condition in `${{ }}`, and update `actions/checkout` from `v4` to `v6`.

## Why?

To resolve Node.js 20 deprecation and expression syntax warnings:

```console
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4.
```

```console
Workflow syntax warning: .github/workflows/require-codeowners.yml#L35
                                                                                                                                     
.github/workflows/require-codeowners.yml (Line: 35, Col: 9): Conditional expression contains literal text outside replacement tokens. This will cause the expression to always evaluate to truthy. Did you mean to put the entire expression inside ${{ }}?
```

