### PR TITLE
Add Opengrep composite action

### DIFF
--- a/.github/workflows/opengrep.yml
+++ b/.github/workflows/opengrep.yml
@@ -1,0 +1,18 @@
+name: Opengrep SAST
+
+on:
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+# Do NOT use cancel-in-progress — it breaks required workflow checks.
+
+jobs:
+  scan:
+    name: opengrep/scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: temporalio/public-actions/sast/opengrep@main

--- a/.github/workflows/opengrep.yml
+++ b/.github/workflows/opengrep.yml
@@ -14,5 +14,5 @@ jobs:
     name: opengrep/scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: temporalio/public-actions/sast/opengrep@main

--- a/sast/opengrep/README.md
+++ b/sast/opengrep/README.md
@@ -1,0 +1,80 @@
+# opengrep
+
+Differential SAST with [Opengrep](https://opengrep.dev) for pull requests. Scans the current branch and compares against the base branch using `--baseline-commit`, **failing only on newly introduced findings**. Pre-existing findings are reported in the job summary but don't block the PR.
+
+## Usage
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: temporalio/public-actions/sast/opengrep@main
+```
+
+That's it. On `pull_request` and `merge_group` events, `baseline-sha` is automatically detected and the scan is differential. On other events, all findings are treated as new.
+
+## Inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `version` | `v1.21.0` | Opengrep version to install |
+| `baseline-sha` | Auto-detected | Base SHA for differential scanning. Override to compare against a specific commit. |
+| `config` | _(empty)_ | Additional rule config (path or URL). Built-in rules always run. |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `new-count` | Number of new findings introduced by this change |
+| `has-new-findings` | `true` if new findings were found, `false` otherwise |
+
+### Using outputs
+
+```yaml
+- uses: temporalio/public-actions/sast/opengrep@main
+  id: sast
+
+- if: steps.sast.outputs.has-new-findings == 'true'
+  run: echo "${{ steps.sast.outputs.new-count }} new findings"
+```
+
+## Job summary
+
+The action writes a GitHub job summary with:
+- **New findings** — introduced by this change (blocks the PR)
+- **Total findings** — all findings across the repo, grouped by rule (informational)
+
+New findings also appear as `::error::` annotations inline on the PR diff.
+
+## Built-in rules
+
+| Rule | Languages | What it detects |
+|---|---|---|
+| `security.gha.missing-explicit-permissions-temporal` | yaml | GitHub Actions workflows without explicit `permissions:` |
+| `security.gha.deprecated.tibdex-github-app-token` | yaml | Deprecated `tibdex/github-app-token` usage |
+| `security.go-zipslip-archive-path-traversal` | go | Unvalidated archive extraction paths (zip slip) |
+
+Additional rules can be supplied via the `config` input — a path to a directory of YAML rule files in your repo, or a URL to a rule file:
+
+```yaml
+# Add repo-local custom rules
+- uses: temporalio/public-actions/sast/opengrep@main
+  with:
+    config: .opengrep/rules/
+```
+
+Rules use the [Opengrep rule syntax](https://opengrep.dev/docs/writing-rules). Teams can add their own rules by creating YAML files in any directory and pointing `config` at it.
+
+## Suppressions
+
+Add a `noopengrep` comment on the matching line to suppress a finding:
+
+```go
+path := filepath.Join(dst, f.Name) // noopengrep: security.go-zipslip-archive-path-traversal
+```
+
+Opengrep also honors `.semgrepignore` files for excluding paths from scanning.
+
+## Prerequisites
+
+- `jq` must be available on the runner (pre-installed on GitHub-hosted runners)
+- No other setup required — the action downloads the Opengrep binary automatically

--- a/sast/opengrep/action.yml
+++ b/sast/opengrep/action.yml
@@ -1,0 +1,199 @@
+name: 'opengrep'
+description: >-
+  Differential SAST with Opengrep — scans for new findings on PRs,
+  generates Job Summary with annotations.
+
+inputs:
+  version:
+    description: 'Opengrep version to install'
+    required: false
+    default: 'v1.21.0'
+  baseline-sha:
+    description: >-
+      Base SHA for differential scanning. Auto-detected on pull_request
+      and merge_group events. When empty, all findings are treated as new.
+    required: false
+    default: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+  config:
+    description: >-
+      Additional rule config (path or opengrep registry ref).
+      Built-in Temporal rules always run.
+    required: false
+    default: ''
+
+outputs:
+  new-count:
+    description: 'Number of new findings'
+    value: ${{ steps.report.outputs.new-count }}
+  has-new-findings:
+    description: 'Whether new findings were found (true/false)'
+    value: ${{ steps.report.outputs.has-new-findings }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install cosign
+      uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+
+    - name: Install opengrep
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        INSTALL_DIR="${RUNNER_TEMP}/opengrep-install"
+        mkdir -p "$INSTALL_DIR"
+
+        # Release assets are standalone binaries, not tarballs.
+        # See: https://github.com/opengrep/opengrep/releases
+        ASSET_NAME="opengrep_manylinux_x86"
+        RELEASE_URL="https://github.com/opengrep/opengrep/releases/download/${VERSION}"
+
+        echo "::group::Install opengrep ${VERSION}"
+        trap 'echo "::endgroup::"' EXIT
+
+        curl -fsSL "${RELEASE_URL}/${ASSET_NAME}" -o "${INSTALL_DIR}/opengrep"
+
+        # Download Sigstore artifacts (best-effort — may not exist for all releases).
+        curl -fsSL "${RELEASE_URL}/${ASSET_NAME}.sig"  -o "${INSTALL_DIR}/opengrep.sig"  2>/dev/null || true
+        curl -fsSL "${RELEASE_URL}/${ASSET_NAME}.cert" -o "${INSTALL_DIR}/opengrep.cert" 2>/dev/null || true
+
+        # Sigstore verification: fail if cosign is present and signatures exist but
+        # verification fails. Warn (don't fail) if cosign or signatures are missing.
+        if command -v cosign &>/dev/null; then
+          if [ -s "${INSTALL_DIR}/opengrep.sig" ] && [ -s "${INSTALL_DIR}/opengrep.cert" ]; then
+            cosign verify-blob \
+              --certificate "${INSTALL_DIR}/opengrep.cert" \
+              --signature "${INSTALL_DIR}/opengrep.sig" \
+              --certificate-identity-regexp "https://github.com/opengrep/opengrep/" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              "${INSTALL_DIR}/opengrep"
+            echo "Sigstore verification: passed"
+          else
+            echo "::warning::Sigstore artifacts not found for ${VERSION} — skipping binary verification"
+          fi
+        else
+          echo "::warning::cosign not found — skipping Sigstore binary verification"
+        fi
+
+        chmod +x "${INSTALL_DIR}/opengrep"
+        echo "${INSTALL_DIR}" >> "$GITHUB_PATH"
+
+    - name: Fetch baseline
+      if: ${{ inputs.baseline-sha != '' }}
+      id: baseline
+      shell: bash
+      env:
+        BASE_SHA: ${{ inputs.baseline-sha }}
+      run: |
+        # Fetch the base commit into the object store.
+        if ! git fetch --depth=1 origin "$BASE_SHA" 2>/dev/null; then
+          echo "::warning::Failed to fetch baseline commit ${BASE_SHA} — all findings will be treated as new"
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # --baseline-commit uses git diff --merge-base which requires the
+        # merge base to be reachable. A shallow clone (depth 1) hides the
+        # commit's parents, so deepen by 1 to expose them.
+        git fetch --deepen=1 origin 2>/dev/null || true
+
+        echo "available=true" >> "$GITHUB_OUTPUT"
+
+    - name: Differential scan
+      shell: bash
+      env:
+        BASELINE_SHA: ${{ steps.baseline.outputs.available == 'true' && inputs.baseline-sha || '' }}
+        ADDITIONAL_CONFIG: ${{ inputs.config }}
+      run: |
+        SCAN_ARGS=(scan --no-rewrite-rule-ids --config "${GITHUB_ACTION_PATH}/rules/")
+        if [ -n "$ADDITIONAL_CONFIG" ]; then
+          SCAN_ARGS+=(--config "$ADDITIONAL_CONFIG")
+        fi
+        SCAN_ARGS+=(--json --error)
+        if [ -n "$BASELINE_SHA" ]; then
+          SCAN_ARGS+=(--baseline-commit "$BASELINE_SHA")
+        fi
+        SCAN_ARGS+=(.)
+
+        set +e
+        opengrep "${SCAN_ARGS[@]}" > "${RUNNER_TEMP}/new-findings.json" 2>"${RUNNER_TEMP}/diff-scan.stderr"
+        exit_code=$?
+        set -e
+
+        # 0 = no new findings, 1 = new findings (with --error), 2+ = scan error.
+        case $exit_code in
+          0|1) ;;
+          *)
+            # --baseline-commit can fail in shallow clones. Fall back to a
+            # non-differential scan so the check still runs (all findings = new).
+            if [ -n "$BASELINE_SHA" ]; then
+              echo "::warning::Differential scan failed (exit ${exit_code}) — retrying without --baseline-commit (all findings will be treated as new)"
+              if [ -s "${RUNNER_TEMP}/diff-scan.stderr" ]; then
+                echo "::group::opengrep scan stderr (differential)"
+                cat "${RUNNER_TEMP}/diff-scan.stderr" >&2
+                echo "::endgroup::"
+              fi
+
+              SCAN_ARGS=(scan --no-rewrite-rule-ids --config "${GITHUB_ACTION_PATH}/rules/")
+              if [ -n "$ADDITIONAL_CONFIG" ]; then
+                SCAN_ARGS+=(--config "$ADDITIONAL_CONFIG")
+              fi
+              SCAN_ARGS+=(--json --error .)
+
+              set +e
+              opengrep "${SCAN_ARGS[@]}" > "${RUNNER_TEMP}/new-findings.json" 2>"${RUNNER_TEMP}/diff-scan.stderr"
+              exit_code=$?
+              set -e
+
+              case $exit_code in
+                0|1) ;;
+                *)
+                  echo "::group::opengrep scan stderr"
+                  cat "${RUNNER_TEMP}/diff-scan.stderr" >&2
+                  echo "::endgroup::"
+                  exit "$exit_code"
+                  ;;
+              esac
+            else
+              echo "::group::opengrep scan stderr"
+              cat "${RUNNER_TEMP}/diff-scan.stderr" >&2
+              echo "::endgroup::"
+              exit "$exit_code"
+            fi
+            ;;
+        esac
+
+    - name: Full scan
+      shell: bash
+      env:
+        ADDITIONAL_CONFIG: ${{ inputs.config }}
+      run: |
+        SCAN_ARGS=(scan --no-rewrite-rule-ids --config "${GITHUB_ACTION_PATH}/rules/")
+        if [ -n "$ADDITIONAL_CONFIG" ]; then
+          SCAN_ARGS+=(--config "$ADDITIONAL_CONFIG")
+        fi
+        SCAN_ARGS+=(--json .)
+
+        set +e
+        opengrep "${SCAN_ARGS[@]}" > "${RUNNER_TEMP}/all-findings.json" 2>"${RUNNER_TEMP}/full-scan.stderr"
+        exit_code=$?
+        set -e
+
+        # Informational only — warn on errors but don't fail the step.
+        if [ "$exit_code" -ne 0 ]; then
+          echo "::warning::Full scan failed (exit ${exit_code}) — total findings summary may be incomplete"
+          echo '{"results":[],"errors":[],"paths":{"scanned":[]}}' > "${RUNNER_TEMP}/all-findings.json"
+        fi
+
+    - name: Report
+      id: report
+      shell: bash
+      run: |
+        # Ensure files exist even if prior steps were skipped.
+        touch "${RUNNER_TEMP}/new-findings.json"
+        touch "${RUNNER_TEMP}/all-findings.json"
+        "$GITHUB_ACTION_PATH/scripts/opengrep-report.sh" \
+          "${RUNNER_TEMP}/new-findings.json" \
+          "${RUNNER_TEMP}/all-findings.json"

--- a/sast/opengrep/rules/deprecated-actions.yml
+++ b/sast/opengrep/rules/deprecated-actions.yml
@@ -1,0 +1,26 @@
+rules:
+  - id: security.gha.deprecated.tibdex-github-app-token
+    message: >
+      Deprecated action `tibdex/github-app-token` detected. Replace with
+      `actions/create-github-app-token` (first-party).
+    severity: WARNING
+    languages:
+      - yaml
+    paths:
+      include:
+        - .github/workflows/**
+        - "**/action.yml"
+        - "**/action.yaml"
+    patterns:
+      - pattern: |
+          uses: $ACTION
+      - metavariable-regex:
+          metavariable: $ACTION
+          regex: ^tibdex/github-app-token(@.*)?$
+    fix: |
+      uses: actions/create-github-app-token@v2
+    metadata:
+      category: security
+      references:
+        - https://github.com/tibdex/github-app-token
+        - https://github.com/actions/create-github-app-token

--- a/sast/opengrep/rules/gha-permissions.yml
+++ b/sast/opengrep/rules/gha-permissions.yml
@@ -1,0 +1,29 @@
+rules:
+  - id: security.gha.missing-explicit-permissions-temporal
+    languages:
+      - yaml
+    severity: ERROR
+    message: >
+      No explicit `GITHUB_TOKEN` permissions found at the workflow or job level.
+      Add a `permissions:` block at the workflow root (applies to all jobs) or
+      per job with least privilege (e.g., `contents: read` and only specific
+      writes like `pull-requests: write` if needed).
+    patterns:
+      - pattern-inside: |
+          jobs:
+            ...
+      - pattern-inside: |-
+          runs-on: ...
+          ...
+      - pattern-not-inside: |
+          ...
+          permissions:
+            $ACTIONS: ...
+          ...
+      - pattern-not-inside: |
+          ...
+          permissions: ...
+          ...
+    paths:
+      include:
+        - .github/workflows/**

--- a/sast/opengrep/rules/go-zipslip.yml
+++ b/sast/opengrep/rules/go-zipslip.yml
@@ -1,0 +1,95 @@
+rules:
+  - id: security.go-zipslip-archive-path-traversal
+    message: >-
+      Potential ZIP Slip path traversal vulnerability. The archive entry name
+      is used with `filepath.Join` to construct a file path without validating
+      that the result stays within the destination directory. A malicious
+      archive with entries like `../../etc/crontab` can write files outside the
+      extraction directory. Note that string-based mitigations like
+      `strings.HasPrefix` and `filepath.IsLocal` defend against `..` traversal
+      but do NOT prevent symlink-based archive attacks or TOCTOU races. Use
+      `os.OpenRoot` / `os.Root` (Go 1.24+) for complete protection.
+    severity: WARNING
+    languages:
+      - go
+    metadata:
+      cwe:
+        - "CWE-22: Improper Limitation of a Pathname to a Restricted Directory
+          ('Path Traversal')"
+      owasp:
+        - A01:2021 - Broken Access Control
+      references:
+        - https://go.dev/blog/osroot
+        - https://snyk.io/research/zip-slip-vulnerability
+        - https://github.com/golang/go/issues/40373
+      category: security
+      technology:
+        - go
+      confidence: HIGH
+    pattern-either:
+      - patterns:
+          - pattern-inside: |
+              for ..., $F := range $READER.File {
+                ...
+              }
+          - pattern-either:
+              - pattern: $PATH = filepath.Join(..., $F.Name, ...)
+              - pattern: $PATH = path.Join(..., $F.Name, ...)
+          - focus-metavariable: $PATH
+          - pattern-not-inside: |
+              for ..., $F := range $READER.File {
+                ...
+                if <... strings.HasPrefix($PATH, ...) ...> {
+                  ...
+                }
+                ...
+              }
+          - pattern-not-inside: |
+              for ..., $F := range $READER.File {
+                ...
+                if <... strings.Contains($F.Name, "..") ...> {
+                  ...
+                }
+                ...
+              }
+          - pattern-not-inside: |
+              for ..., $F := range $READER.File {
+                ...
+                if <... filepath.IsLocal($F.Name) ...> {
+                  ...
+                }
+                ...
+              }
+      - patterns:
+          - pattern-inside: |
+              func $FUNC(..., $F *zip.File, ...) {
+                ...
+              }
+          - pattern-either:
+              - pattern: $PATH = filepath.Join(..., $F.Name, ...)
+              - pattern: $PATH = path.Join(..., $F.Name, ...)
+          - focus-metavariable: $PATH
+          - pattern-not-inside: |
+              func $FUNC(..., $F *zip.File, ...) {
+                ...
+                if <... strings.HasPrefix($PATH, ...) ...> {
+                  ...
+                }
+                ...
+              }
+          - pattern-not-inside: |
+              func $FUNC(..., $F *zip.File, ...) {
+                ...
+                if <... strings.Contains($F.Name, "..") ...> {
+                  ...
+                }
+                ...
+              }
+          - pattern-not-inside: |
+              func $FUNC(..., $F *zip.File, ...) {
+                ...
+                if <... filepath.IsLocal($F.Name) ...> {
+                  ...
+                }
+                ...
+              }

--- a/sast/opengrep/scripts/opengrep-report.sh
+++ b/sast/opengrep/scripts/opengrep-report.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# opengrep-report.sh — Parse Opengrep JSON results, write a GitHub job summary
+# with ::error:: annotations for new findings.
+#
+# Usage:
+#   opengrep-report.sh <new-findings.json> <all-findings.json>
+#
+# Environment variables (set automatically by GitHub Actions):
+#   GITHUB_STEP_SUMMARY — path to the job summary file (falls back to stdout)
+#   GITHUB_OUTPUT       — path to expose step outputs
+#
+# Local testing:
+#   opengrep scan --config rules/ --json --error . > /tmp/new.json 2>/dev/null; true
+#   opengrep scan --config rules/ --json . > /tmp/all.json
+#   ./opengrep-report.sh /tmp/new.json /tmp/all.json
+#
+# Expected Opengrep JSON format (same as Semgrep):
+#   {
+#     "results": [
+#       {
+#         "check_id": "rule.id",
+#         "path": "file.yml",
+#         "start": {"line": 9, "col": 1},
+#         "end":   {"line": 9, "col": 40},
+#         "extra": {
+#           "severity": "WARNING",
+#           "message": "Rule message text",
+#           "fingerprint": "...",
+#           "lines": "    matching source line"
+#         }
+#       }
+#     ],
+#     "errors": [],
+#     "paths": { "scanned": ["file1.yml", "file2.go"] }
+#   }
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Count findings in a JSON results file. Returns 0 for empty/missing/malformed.
+count_findings() {
+  local json_file=$1
+  if [ ! -s "$json_file" ]; then
+    echo 0
+    return
+  fi
+  jq '.results | length' "$json_file" 2>/dev/null || echo 0
+}
+
+# Count scanned files. Returns 0 for empty/missing/malformed.
+count_scanned() {
+  local json_file=$1
+  if [ ! -s "$json_file" ]; then
+    echo 0
+    return
+  fi
+  jq '.paths.scanned | length' "$json_file" 2>/dev/null || echo 0
+}
+
+# Emit ::error:: annotations for each finding (visible on PR diff).
+emit_annotations() {
+  local json_file=$1
+  if [ ! -s "$json_file" ]; then
+    return
+  fi
+  jq -r '
+    .results[] |
+    "::error file=\(.path),line=\(.start.line)::\(.check_id): \(.extra.message)"
+  ' "$json_file" 2>/dev/null || true
+}
+
+# Emit a markdown table of findings. Escapes pipe characters in messages.
+findings_table() {
+  local json_file=$1
+  jq -r '
+    .results[] |
+    "| `\(.check_id)` | `\(.path)` | \(.start.line) | \(.extra.severity) | \(.extra.message | gsub("\\|"; "\\|")) |"
+  ' "$json_file"
+}
+
+# ---------------------------------------------------------------------------
+# Render: write the GitHub job summary
+# ---------------------------------------------------------------------------
+
+write_summary() {
+  local new_json=$1
+  local all_json=$2
+  local new_count=$3
+  local all_count=$4
+  local scanned_count=$5
+  local summary_file="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+  {
+    echo "## SAST Scan"
+    echo ""
+
+    if [ "$scanned_count" -eq 0 ]; then
+      echo "No files matched configured rules."
+      return
+    fi
+
+    if [ "$new_count" -gt 0 ]; then
+      echo "### :warning: New findings ($new_count)"
+      echo ""
+      echo "| Rule | File | Line | Severity | Message |"
+      echo "|------|------|------|----------|---------|"
+      findings_table "$new_json" 2>/dev/null || true
+      echo ""
+    else
+      echo "### :white_check_mark: No new findings"
+      echo ""
+      echo "This change does not introduce any new SAST findings."
+      echo ""
+    fi
+
+    if [ "$all_count" -gt 0 ]; then
+      echo "### Total findings ($all_count)"
+      echo ""
+      echo "<details><summary>Click to expand</summary>"
+      echo ""
+      echo "| Rule | Count |"
+      echo "|------|-------|"
+      jq -r '
+        [.results[] | .check_id] |
+        group_by(.) |
+        map({rule: .[0], count: length}) |
+        sort_by(-.count) |
+        .[] |
+        "| `\(.rule)` | \(.count) |"
+      ' "$all_json" 2>/dev/null || true
+      echo ""
+      echo "</details>"
+    fi
+  } >> "$summary_file"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  local new_json="${1:?Usage: opengrep-report.sh <new-findings.json> <all-findings.json>}"
+  local all_json="${2:?Usage: opengrep-report.sh <new-findings.json> <all-findings.json>}"
+
+  if ! command -v jq &>/dev/null; then
+    echo "::error::jq is required but not installed — use a GitHub-hosted runner or install jq"
+    exit 1
+  fi
+
+  local new_count all_count scanned_count
+  new_count=$(count_findings "$new_json")
+  all_count=$(count_findings "$all_json")
+  scanned_count=$(count_scanned "$all_json")
+
+  # Emit ::error:: annotations for new findings (visible on PR diff).
+  if [ "$new_count" -gt 0 ]; then
+    emit_annotations "$new_json"
+  fi
+
+  # Write GitHub job summary.
+  write_summary "$new_json" "$all_json" "$new_count" "$all_count" "$scanned_count"
+
+  # Expose outputs for downstream workflow steps.
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "new-count=${new_count}" >> "$GITHUB_OUTPUT"
+    echo "has-new-findings=$([ "$new_count" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+  fi
+
+  # Fail the check when new findings are introduced.
+  if [ "$new_count" -gt 0 ]; then
+    exit 1
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
This PR introduces a _future_ [**required workflow**](https://github.com/temporalio/public-actions/blob/aa97332cb76a47a23f1565019593f4984c4e72b3/.github/workflows/opengrep.yml) + a [**composite action**](https://github.com/temporalio/public-actions/blob/aa97332cb76a47a23f1565019593f4984c4e72b3/sast/opengrep/action.yml) for _differential_ SAST scanning with Opengrep. Somewhat similar to #18. 

Th action downloads a pinned binary with [Sigstore](https://www.sigstore.dev/) verification, runs a differential scan (`--baseline-commit`) to gate PRs on _new findings only_, and a full scan for the job summary landscape view.

Includes three vendored rules (@keeravani and I will figure out a potentially better path forward) and a `bash`+`jq` report script that emits `::error:: `annotations and a GitHub job summary.


> [!NOTE] 
> The `opengrep/scan` job [fails](https://github.com/temporalio/public-actions/actions/runs/25938752175/job/76250748742?pr=19) because the workflow references `temporalio/public-actions/sast/opengrep@main` and the action doesn't exist on `main` **_yet_**. 
>
> **This resolves on merge:** it's a bootstrap issue that any PR adding a new action hits. The action _was validated on-branch_ with `@opengrep` in prior [runs](https://github.com/temporalio/public-actions/actions/runs/25938498212/job/76249879678?pr=19) before squashing commits to be ready for review.