### PR TITLE
Add opt-in inline PR review comments to Opengrep action

### DIFF
--- a/sast/opengrep/README.md
+++ b/sast/opengrep/README.md
@@ -6,7 +6,7 @@ Differential SAST with [Opengrep](https://opengrep.dev) for pull requests. Scans
 
 ```yaml
 steps:
-  - uses: actions/checkout@v4
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   - uses: temporalio/public-actions/sast/opengrep@main
 ```
 
@@ -56,7 +56,7 @@ permissions:
   pull-requests: write
 
 steps:
-  - uses: actions/checkout@v4
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   - uses: temporalio/public-actions/sast/opengrep@main
     with:
       pr-comments: 'true'

--- a/sast/opengrep/README.md
+++ b/sast/opengrep/README.md
@@ -19,6 +19,7 @@ That's it. On `pull_request` and `merge_group` events, `baseline-sha` is automat
 | `version` | `v1.21.0` | Opengrep version to install |
 | `baseline-sha` | Auto-detected | Base SHA for differential scanning. Override to compare against a specific commit. |
 | `config` | _(empty)_ | Additional rule config (path or URL). Built-in rules always run. |
+| `pr-comments` | `false` | Post findings as inline PR review comments (opt-in, see below). |
 
 ## Outputs
 
@@ -44,6 +45,28 @@ The action writes a GitHub job summary with:
 - **Total findings** — all findings across the repo, grouped by rule (informational)
 
 New findings also appear as `::error::` annotations inline on the PR diff.
+
+## PR review comments
+
+Set `pr-comments: 'true'` to post findings as inline review comments directly on the PR diff, similar to Semgrep's managed scans. This requires `pull-requests: write` permission:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+
+steps:
+  - uses: actions/checkout@v4
+  - uses: temporalio/public-actions/sast/opengrep@main
+    with:
+      pr-comments: 'true'
+```
+
+Comments are deduplicated across runs using the finding fingerprint — re-running the action on the same PR won't create duplicate comments. Each comment includes suppression guidance. Multi-line findings highlight the full matched range in the diff.
+
+When a finding is fixed, the action strikes through the original comment and attempts to resolve the review thread. Thread resolution requires a GitHub App token or PAT — the default `GITHUB_TOKEN` can update the comment body but cannot resolve threads via GraphQL (`Resource not accessible by integration`).
+
+When a finding's line isn't part of the diff (edge case), the action falls back to a single PR comment with a table of findings and clickable links. This fallback comment is updated in-place on subsequent runs to avoid notification noise.
 
 ## Built-in rules
 

--- a/sast/opengrep/action.yml
+++ b/sast/opengrep/action.yml
@@ -20,6 +20,12 @@ inputs:
       Built-in Temporal rules always run.
     required: false
     default: ''
+  pr-comments:
+    description: >-
+      Post findings as inline PR review comments (requires
+      pull-requests: write permission). Only applies on pull_request events.
+    required: false
+    default: 'false'
 
 outputs:
   new-count:
@@ -190,6 +196,11 @@ runs:
     - name: Report
       id: report
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_COMMENTS_ENABLED: ${{ inputs.pr-comments }}
       run: |
         # Ensure files exist even if prior steps were skipped.
         touch "${RUNNER_TEMP}/new-findings.json"

--- a/sast/opengrep/rules/deprecated-actions.yml
+++ b/sast/opengrep/rules/deprecated-actions.yml
@@ -20,6 +20,7 @@ rules:
     fix: |
       uses: actions/create-github-app-token@v2
     metadata:
+      source: sast/opengrep/rules/deprecated-actions.yml
       category: security
       references:
         - https://github.com/tibdex/github-app-token

--- a/sast/opengrep/rules/gha-permissions.yml
+++ b/sast/opengrep/rules/gha-permissions.yml
@@ -8,6 +8,8 @@ rules:
       Add a `permissions:` block at the workflow root (applies to all jobs) or
       per job with least privilege (e.g., `contents: read` and only specific
       writes like `pull-requests: write` if needed).
+    metadata:
+      source: sast/opengrep/rules/gha-permissions.yml
     patterns:
       - pattern-inside: |
           jobs:

--- a/sast/opengrep/rules/go-zipslip.yml
+++ b/sast/opengrep/rules/go-zipslip.yml
@@ -13,6 +13,7 @@ rules:
     languages:
       - go
     metadata:
+      source: sast/opengrep/rules/go-zipslip.yml
       cwe:
         - "CWE-22: Improper Limitation of a Pathname to a Restricted Directory
           ('Path Traversal')"

--- a/sast/opengrep/scripts/opengrep-report.sh
+++ b/sast/opengrep/scripts/opengrep-report.sh
@@ -71,6 +71,330 @@ emit_annotations() {
   ' "$json_file" 2>/dev/null || true
 }
 
+# Resolve Opengrep review threads whose findings no longer appear in the scan.
+# This keeps the PR conversation clean when developers fix flagged issues.
+resolve_stale_threads() {
+  local json_file=$1
+
+  if [ "${PR_COMMENTS_ENABLED:-}" != "true" ]; then
+    return
+  fi
+  if [ -z "${GITHUB_TOKEN:-}" ] || [ -z "${PR_NUMBER:-}" ]; then
+    return
+  fi
+  if ! command -v gh &>/dev/null; then
+    return
+  fi
+
+  local repo="${GITHUB_REPOSITORY}"
+  local owner="${repo%%/*}"
+  local name="${repo##*/}"
+
+  # Collect current finding fingerprints (empty set if no findings file).
+  local current_fps
+  current_fps=$(jq '[.results[]? | .extra.fingerprint // empty] | unique' \
+    "$json_file" 2>/dev/null) || current_fps="[]"
+
+  # Fetch all unresolved Opengrep review threads via GraphQL.
+  # Include databaseId so we can PATCH the comment body via REST.
+  local threads
+  threads=$(gh api graphql -f query='
+    query($owner: String!, $name: String!, $pr: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $pr) {
+          reviewThreads(first: 100) {
+            nodes {
+              id
+              isResolved
+              comments(first: 1) {
+                nodes { body databaseId }
+              }
+            }
+          }
+        }
+      }
+    }' -f owner="$owner" -f name="$name" -F pr="$PR_NUMBER" \
+    --jq '
+      [.data.repository.pullRequest.reviewThreads.nodes[] |
+        select(.isResolved == false) |
+        select(.comments.nodes[0].body | test("<!-- opengrep:")) |
+        {
+          thread_id: .id,
+          comment_id: .comments.nodes[0].databaseId,
+          body: .comments.nodes[0].body,
+          fp: (.comments.nodes[0].body |
+            capture("<!-- opengrep:(?<fp>[^\\s]+) -->") | .fp)
+        }
+      ]
+    ' 2>/dev/null) || return 0
+
+  # Filter to threads whose fingerprint is no longer in the current findings.
+  local stale_threads
+  stale_threads=$(echo "$threads" | jq --argjson current "$current_fps" '
+    [.[] | select([.fp] - $current | length > 0)]
+  ' 2>/dev/null) || return 0
+
+  local stale_count
+  stale_count=$(echo "$stale_threads" | jq 'length')
+  if [ "$stale_count" -eq 0 ]; then
+    return
+  fi
+
+  local head_sha="${PR_HEAD_SHA:-${GITHUB_SHA:-unknown}}"
+  local server_url="${GITHUB_SERVER_URL:-https://github.com}"
+
+  # For each stale thread: strike through the comment body and resolve.
+  # Build a list of {thread_id, comment_id, new_body} to process.
+  # The new body preserves the fingerprint marker (for dedup), strikes through
+  # the original message, drops the suppress/suggestion blocks, and adds a
+  # commit link showing when the finding was fixed.
+  local resolved_threads
+  resolved_threads=$(echo "$stale_threads" | jq \
+    --arg sha "$head_sha" \
+    --arg server "$server_url" \
+    --arg repo "$repo" '
+    [.[] | {
+      thread_id,
+      comment_id: (.comment_id | tostring),
+      new_body: (
+        "<!-- opengrep:" + .fp + " -->\n" +
+        "<strike>\n\n" + (.body |
+          gsub("<!-- opengrep:[^>]+ -->\\n?"; "") |
+          gsub("\\n\\n```suggestion[\\s\\S]*?```"; "") |
+          gsub("\\n---\\n<details>[\\s\\S]*</details>"; "") |
+          rtrimstr("\n")
+        ) + "\n\n</strike>\n\n" +
+        "Fixed in [`" + $sha[0:7] + "`](" +
+          $server + "/" + $repo + "/commit/" + $sha + ")"
+      )
+    }]
+  ' 2>/dev/null) || return 0
+
+  local i thread_id comment_id new_body
+  for i in $(seq 0 $((stale_count - 1))); do
+    thread_id=$(echo "$resolved_threads" | jq -r ".[$i].thread_id")
+    comment_id=$(echo "$resolved_threads" | jq -r ".[$i].comment_id")
+    new_body=$(echo "$resolved_threads" | jq -r ".[$i].new_body")
+
+    # Update the comment body via REST.
+    if gh api "repos/${repo}/pulls/comments/${comment_id}" \
+      --method PATCH \
+      -f body="$new_body" > /dev/null 2>&1; then
+      echo "Struck through comment ${comment_id}"
+    else
+      echo "::warning::Failed to update comment ${comment_id}"
+    fi
+
+    # Resolve the thread via GraphQL.
+    local resolve_result
+    if resolve_result=$(gh api graphql -f query='
+      mutation($id: ID!) {
+        resolveReviewThread(input: {threadId: $id}) {
+          thread { isResolved }
+        }
+      }' -f id="$thread_id" 2>&1); then
+      echo "Resolved thread ${thread_id}"
+    else
+      echo "::warning::Failed to resolve thread ${thread_id}: $(echo "$resolve_result" | tr '\n' ' ')"
+    fi
+  done
+
+  echo "Processed ${stale_count} stale Opengrep review thread(s)"
+}
+
+# Post findings as inline PR review comments via the GitHub API.
+# Each comment embeds the finding fingerprint as an HTML comment so that
+# repeat runs on the same PR skip findings that were already commented on.
+post_pr_comments() {
+  local json_file=$1
+
+  if [ "${PR_COMMENTS_ENABLED:-}" != "true" ]; then
+    return
+  fi
+  if [ -z "${GITHUB_TOKEN:-}" ]; then
+    echo "::warning::pr-comments enabled but no GITHUB_TOKEN available — skipping PR review comments"
+    return
+  fi
+  if [ -z "${PR_NUMBER:-}" ]; then
+    echo "::debug::Not a pull_request event — skipping PR review comments"
+    return
+  fi
+  if [ ! -s "$json_file" ]; then
+    return
+  fi
+
+  local repo="${GITHUB_REPOSITORY}"
+  local commit_sha="${PR_HEAD_SHA:-}"
+  if [ -z "$commit_sha" ]; then
+    echo "::warning::PR head SHA not available — skipping PR review comments"
+    return
+  fi
+
+  if ! command -v gh &>/dev/null; then
+    echo "::warning::gh CLI not found — skipping PR review comments"
+    return
+  fi
+
+  # --- Deduplication: fetch existing review comments and collect fingerprints
+  # already posted by a previous run so we don't repeat them.  gh handles
+  # pagination automatically via --paginate.  Each page is a JSON array of
+  # comment objects; --jq extracts fingerprints per page, then jq -s merges
+  # all pages into a single unique list.
+  local existing_fingerprints
+  if ! existing_fingerprints=$(gh api \
+    --paginate \
+    "repos/${repo}/pulls/${PR_NUMBER}/comments" \
+    --jq '
+      [.[] | .body // empty |
+        select(test("<!-- opengrep:")) |
+        capture("<!-- opengrep:(?<fp>[^\\s]+) -->") | .fp
+      ]
+    ' | jq -s 'add | unique // []'); then
+    echo "::warning::Failed to fetch existing PR comments for dedup — may repost findings"
+    existing_fingerprints="[]"
+  fi
+
+  # --- Build review comments, skipping already-posted fingerprints.
+  # Uses start_line/line to highlight the full matched range when the finding
+  # spans multiple lines (GitHub renders this as a multi-line comment).
+  # Construct a base URL for rule source links from the action's own repo/ref.
+  # GITHUB_ACTION_REPOSITORY isn't set for shell steps in composite actions,
+  # so parse the repo and ref from GITHUB_ACTION_PATH instead:
+  #   /home/runner/work/_actions/{owner}/{repo}/{ref}/...
+  local action_repo="" action_ref=""
+  if [[ "${GITHUB_ACTION_PATH:-}" =~ _actions/([^/]+/[^/]+)/([^/]+)/ ]]; then
+    action_repo="${BASH_REMATCH[1]}"
+    action_ref="${BASH_REMATCH[2]}"
+  fi
+  local server_url="${GITHUB_SERVER_URL:-https://github.com}"
+  local rule_base_url=""
+  if [ -n "$action_repo" ]; then
+    rule_base_url="${server_url}/${action_repo}/blob/${action_ref}/"
+  fi
+
+  local comments
+  comments=$(jq --argjson seen "$existing_fingerprints" --arg rule_base "$rule_base_url" '
+    [.results[] |
+      select((.extra.fingerprint // "") as $fp |
+        $fp == "" or ([$fp] - $seen | length > 0)) |
+      {
+        path,
+        line: .end.line,
+        side: "RIGHT",
+        body: (
+          "<!-- opengrep:" + (.extra.fingerprint // "unknown") + " -->\n" +
+          "**Opengrep** — " +
+          (if (.extra.metadata.source // null) and $rule_base != "" then
+            "[`\(.check_id)`](" + $rule_base + .extra.metadata.source + ")"
+          else "`\(.check_id)`" end) +
+          " (\(.extra.severity))\n\n" +
+          .extra.message + "\n\n" +
+          # Include a GitHub suggestion block when the rule provides an autofix.
+          # Splice the fix into the original source line to preserve indentation:
+          # prefix (before match start col) + fix + suffix (after match end col).
+          (if .extra.fix then
+            ((.extra.lines | rtrimstr("\n"))[0:.start.col - 1]
+              + (.extra.fix | rtrimstr("\n"))
+              + (.extra.lines | rtrimstr("\n"))[.end.col - 1:]
+            ) as $fixed_line |
+            "```suggestion\n" + $fixed_line + "\n```\n\n"
+          else "" end) +
+          "---\n" +
+          "<details><summary>Suppress this finding</summary>\n\n" +
+          "Add a suppression comment on the line before:\n```\n" +
+          "# noopengrep: \(.check_id)\n" +
+          "```\n\n</details>"
+        )
+      } +
+      # Add start_line only for multi-line findings.
+      if .start.line != .end.line then
+        {start_line: .start.line, start_side: "RIGHT"}
+      else {} end
+    ]
+  ' "$json_file") || return 0
+
+  local comment_count
+  comment_count=$(echo "$comments" | jq 'length')
+  if [ "$comment_count" -eq 0 ]; then
+    echo "All findings already have PR comments — nothing new to post"
+    return
+  fi
+
+  # --- Post a single review with all inline comments.  This places comments
+  # directly on the relevant lines in the PR diff.  If it fails (e.g. a
+  # finding's line isn't part of the diff), fall back to a plain PR comment.
+  local payload
+  payload=$(jq -n \
+    --arg sha "$commit_sha" \
+    --argjson comments "$comments" \
+    '{commit_id: $sha, event: "COMMENT", comments: $comments}')
+
+  local gh_stderr
+  if gh_stderr=$(gh api \
+    "repos/${repo}/pulls/${PR_NUMBER}/reviews" \
+    --method POST \
+    --input - <<< "$payload" 2>&1 >/dev/null); then
+    echo "Posted PR review with ${comment_count} inline comment(s)"
+    return
+  fi
+
+  echo "::debug::Inline review failed, falling back to PR comment. gh api: $(echo "$gh_stderr" | tr '\n' ' ')"
+
+  # --- Fallback: post (or update) a plain PR comment with findings as a table.
+  # Look for an existing Opengrep summary comment to update in-place, avoiding
+  # duplicate comments on every push.
+  local existing_comment_id
+  existing_comment_id=$(gh api \
+    --paginate \
+    "repos/${repo}/issues/${PR_NUMBER}/comments" \
+    --jq '.[] | select(.body | test("<!-- opengrep:summary -->")) | .id' \
+    2>/dev/null | head -1) || existing_comment_id=""
+
+  local server_url="${GITHUB_SERVER_URL:-https://github.com}"
+  local comment_body
+  comment_body=$(jq -r \
+    --arg server "$server_url" \
+    --arg repo "$repo" \
+    --arg sha "$commit_sha" '
+    "<!-- opengrep:summary -->\n" +
+    "### Opengrep — new findings\n\n" +
+    "| Severity | Location | Rule | Message |\n" +
+    "|----------|----------|------|---------|\n" +
+    ([.results[] |
+      "| \(.extra.severity) " +
+      "| [`\(.path):\(.start.line)`](\($server)/\($repo)/blob/\($sha)/\(.path)#L\(.start.line)) " +
+      "| `\(.check_id)` " +
+      "| \(.extra.message | gsub("\\|"; "\\|") | gsub("\n"; " ")) |"
+    ] | join("\n")) +
+    "\n\n---\n" +
+    "<details><summary>Suppress findings</summary>\n\n" +
+    "Add a `noopengrep` comment on the line before the finding:\n" +
+    "```\n# noopengrep: <rule-id>\n```\n\n" +
+    "</details>"
+  ' "$json_file") || return 0
+
+  if [ -n "$existing_comment_id" ]; then
+    # Update the existing comment in-place — no new notification.
+    if gh api \
+      "repos/${repo}/issues/comments/${existing_comment_id}" \
+      --method PATCH \
+      -f body="$comment_body" > /dev/null 2>&1; then
+      echo "Updated existing PR comment with ${comment_count} finding(s)"
+    else
+      echo "::warning::Failed to update PR comment — findings are still shown as annotations and job summary"
+    fi
+  else
+    if gh api \
+      "repos/${repo}/issues/${PR_NUMBER}/comments" \
+      --method POST \
+      -f body="$comment_body" > /dev/null 2>&1; then
+      echo "Posted PR comment with ${comment_count} finding(s) (inline review unavailable)"
+    else
+      echo "::warning::Failed to post PR comment — findings are still shown as annotations and job summary"
+    fi
+  fi
+}
+
 # Emit a markdown table of findings. Escapes pipe characters in messages.
 findings_table() {
   local json_file=$1
@@ -161,6 +485,15 @@ main() {
 
   # Write GitHub job summary.
   write_summary "$new_json" "$all_json" "$new_count" "$all_count" "$scanned_count"
+
+  # Post inline PR review comments for new findings (best-effort — never
+  # blocks outputs or the exit code, which are the authoritative signals).
+  if [ "$new_count" -gt 0 ]; then
+    post_pr_comments "$new_json" || true
+  fi
+
+  # Resolve review threads for findings that were fixed since the last run.
+  resolve_stale_threads "$new_json" || true
 
   # Expose outputs for downstream workflow steps.
   if [ -n "${GITHUB_OUTPUT:-}" ]; then


### PR DESCRIPTION
Added new option to our Opengrep action to post SAST findings as inline review comments on PRs when `pr-comments: 'true'` is set (requires `pull-requests: write` permissions). Uses `gh` CLI for API calls with automatic pagination and auth. Deduplicates across runs via "fingerprint" markers in comments. Falls back to a plain PR comment (with update-in-place dedup) when inline review fails.
