### PR TITLE
Adding PR write permissions for Opengrep to support in-line PR comments

### DIFF
--- a/.github/workflows/opengrep.yml
+++ b/.github/workflows/opengrep.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 # Do NOT use cancel-in-progress — it breaks required workflow checks.
 
@@ -16,3 +17,5 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: temporalio/public-actions/sast/opengrep@main
+        with:
+          pr-comments: 'true'


### PR DESCRIPTION
This will support https://github.com/temporalio/public-actions/pull/20 to update permissions to support Opengrep to do inline review comments on PRs with pr-comments: 'true'