### PR TITLE
VLN-1481: remediate unpinned-github-actions

### DIFF
--- a/.github/workflows/require-codeowners.yml
+++ b/.github/workflows/require-codeowners.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

> ℹ️ Re-resolved 2026-06-24 against an updated base: `main` deleted `.github/workflows/semgrep.yml` (#24) after this PR opened. That file's pin (`actions/checkout` `v4` -> `v4.3.1`) was dropped; only the surviving `require-codeowners.yml` pin remains.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>unpinned-github-actions</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/public-actions</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1481">VLN-1481</a></td></tr>
</table>

## Summary

🤠 [Deputy](https://github.com/temporalio/deputy) pinned dependencies to immutable references.

- Pinned refs: 1

Changed references:
- `actions/checkout`: `v6` -> `df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3`

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — close and retry with a new fix
