### PR TITLE
Add security.gha.unpinned-action Opengrep rule (SEC-2085)

### DIFF
--- a/sast/opengrep/README.md
+++ b/sast/opengrep/README.md
@@ -76,6 +76,7 @@ When a finding's line isn't part of the diff (edge case), the action falls back 
 | `security.gha.run-shell-injection` | yaml | Untrusted `${{ github.* }}` context interpolated into a `run:`/`script:` block (shell injection) |
 | `security.gha.run-shell-injection-inputs` | yaml | _(WARNING)_ Caller-supplied `inputs.*` interpolated into a `run:`/`script:` block — route through `env:` (advisory) |
 | `security.gha.run-shell-injection-refs` | yaml | _(WARNING)_ Non-fork-controlled Git ref (`github.ref`/`base_ref`/`ref_name`/`pull_request.base.ref`) in a `run:`/`script:` block — route through `env:` (advisory) |
+| `security.gha.unpinned-action` | yaml | _(WARNING)_ `uses:` at a mutable tag/branch ref instead of a full 40-character commit SHA, for actions and reusable workflows alike. Excludes `temporalio/*`, local `./`, self-repository `$/`, and `docker://` refs |
 | `security.gha.deprecated.tibdex-github-app-token` | yaml | Deprecated `tibdex/github-app-token` usage |
 | `security.go-zipslip-archive-path-traversal` | go | Unvalidated archive extraction paths (zip slip) |
 

--- a/sast/opengrep/rules/gha-unpinned-actions.yml
+++ b/sast/opengrep/rules/gha-unpinned-actions.yml
@@ -29,8 +29,62 @@ rules:
         - "**/action.yml"
         - "**/action.yaml"
     patterns:
-      - pattern: |
-          uses: $ACTION
+      # `uses` only executes in two places: as a step key, and as a job-level
+      # reusable-workflow call. Anywhere else it is a user-chosen name that
+      # merely reads `uses` (a `with:` input, an `env:` var, a `matrix` entry),
+      # and reporting one would block a PR over a value that never runs.
+      #
+      # Scoped positively, by position, rather than by excluding key names
+      # globally. Excluding names alone is unsound: job ids are user-chosen too,
+      # so a `pattern-not-inside: secrets:` also matches a job *named* `secrets`
+      # and silently drops every unpinned ref in it. That is a real workflow in
+      # this org, and a silent false negative in a security control is worse
+      # than a visible false positive. Anchoring each branch to `steps:` or
+      # `jobs:` first keeps the name exclusions from reaching a whole job.
+      #
+      # The exclusions drop nested keys only, never siblings: an unpinned
+      # `uses:` alongside a `with:` block is still reported, which is by far
+      # the most common real shape.
+      - pattern-either:
+          # A step, in a workflow job or a composite action.
+          - patterns:
+              - pattern: |
+                  uses: $ACTION
+              - pattern-inside: |
+                  steps:
+                    ...
+              - pattern-not-inside: |
+                  with:
+                    ...
+              - pattern-not-inside: |
+                  env:
+                    ...
+          # A job-level reusable-workflow call. Inside `jobs:` but not a step;
+          # a job takes arbitrary keys under these five blocks.
+          - patterns:
+              - pattern: |
+                  uses: $ACTION
+              - pattern-inside: |
+                  jobs:
+                    ...
+              - pattern-not-inside: |
+                  steps:
+                    ...
+              - pattern-not-inside: |
+                  with:
+                    ...
+              - pattern-not-inside: |
+                  env:
+                    ...
+              - pattern-not-inside: |
+                  secrets:
+                    ...
+              - pattern-not-inside: |
+                  outputs:
+                    ...
+              - pattern-not-inside: |
+                  matrix:
+                    ...
       # Two regexes rather than one: the first says "references a repo at an
       # @ref that is not a 40-hex SHA", the second carves out the excluded
       # prefixes. Both are left-anchored (PCRE2, `re.match` semantics).

--- a/sast/opengrep/rules/gha-unpinned-actions.yml
+++ b/sast/opengrep/rules/gha-unpinned-actions.yml
@@ -1,0 +1,65 @@
+rules:
+  - id: security.gha.unpinned-action
+    languages:
+      - yaml
+    severity: WARNING
+    message: >
+      Unpinned action reference `$ACTION`: this `uses:` resolves a mutable ref
+      (tag or branch), so the code that runs in CI can change without this line
+      changing. A compromised upstream can repoint the tag and execute arbitrary
+      code with access to this repository's secrets and `GITHUB_TOKEN`
+      (`tj-actions/changed-files`, March 2025). Pin to the full 40-character
+      commit SHA with the resolved version in a trailing comment, e.g.
+      `uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2`.
+      Prefer `deputy pin --ecosystems github-actions`, which resolves the ref,
+      writes a version comment that reflects the most specific ref actually
+      pointing at that commit, and verifies the SHA is reachable from a real
+      branch upstream. That last check matters: pinning alone does not detect
+      imposter or dangling commits, and this rule only sees the shape of the
+      ref, never its provenance. Reusable workflow calls
+      (`owner/repo/.github/workflows/x.yml@ref`) run with the same trust as
+      actions and are pinned the same way. Not reported, by campaign policy:
+      `temporalio/*` refs (first-party, pinned by internal process), local `./`
+      actions, self-repository `$/` refs (resolve to the running commit, so they
+      are already pin-equivalent), and `docker://` images (pinned by digest as a
+      separate ecosystem).
+    paths:
+      include:
+        - .github/workflows/**
+        - "**/action.yml"
+        - "**/action.yaml"
+    patterns:
+      - pattern: |
+          uses: $ACTION
+      # Two regexes rather than one: the first says "references a repo at an
+      # @ref that is not a 40-hex SHA", the second carves out the excluded
+      # prefixes. Both are left-anchored (PCRE2, `re.match` semantics).
+      #
+      # `["']?` appears in every position because a metavariable bound to a
+      # quoted YAML scalar keeps its quotes (`"actions/checkout@v4"`, verified
+      # against opengrep v1.21.0), and the trailing `# vX.Y.Z` comment is not
+      # part of the scalar, so `@<40-hex>$` is a sound end-anchor.
+      - metavariable-regex:
+          metavariable: $ACTION
+          regex: ^["']?[^@\s"']+@(?![0-9a-fA-F]{40}["']?$)\S+$
+      # The optional quote lives INSIDE the negative lookahead on purpose. With
+      # `^["']?(?!...)` the engine backtracks to the pre-quote position and the
+      # lookahead passes, so `"temporalio/x@v1"` would be reported.
+      - metavariable-regex:
+          metavariable: $ACTION
+          regex: ^(?!["']?(?:\./|\$/|docker://|(?i:temporalio)/))
+    metadata:
+      source: sast/opengrep/rules/gha-unpinned-actions.yml
+      category: security
+      cwe:
+        - "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+      owasp:
+        - A08:2021 - Software and Data Integrity Failures
+      technology:
+        - github-actions
+      confidence: HIGH
+      references:
+        - https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
+        - https://github.com/temporalio/security-models/blob/main/models/supply-chain/security/gha-pipeline-integrity.md#gha-t4-compromised-third-party-action-executes-in-workflow-context
+        - https://github.com/temporalio/security-models/blob/main/models/supply-chain/security/gha-pipeline-integrity.md#gha-t7-imposter-commits-and-dangling-sha-references
+        - https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/

--- a/sast/opengrep/tests/.github/workflows/gha-unpinned-actions.yaml
+++ b/sast/opengrep/tests/.github/workflows/gha-unpinned-actions.yaml
@@ -1,0 +1,105 @@
+# Regression fixture for `security.gha.unpinned-action` (WARNING).
+# Annotation syntax (ruleid / ok) is documented in sast/opengrep/tests/README.md.
+#
+# The rule anchors on the `@ref` portion of a `uses:` value and reports anything
+# that is not a 40-hex commit SHA. Cases below also pin the two behaviours that
+# are invisible by inspection and were verified against opengrep v1.21.0:
+#   1. a quoted scalar binds WITH its quotes, so every regex position tolerates
+#      an optional quote (see the `"actions/upload-artifact@v4"` case);
+#   2. a trailing version comment is not part of the scalar, so the SHA cases
+#      end-anchor cleanly with and without one.
+on: push
+permissions:
+  contents: read
+jobs:
+  steps-level:
+    runs-on: ubuntu-latest
+    steps:
+      # --- must flag ---
+      # tag ref (the drift case from temporalio/temporal-auto-scaled-workers)
+      # ruleid: security.gha.unpinned-action
+      - uses: dorny/test-reporter@v1
+      # ruleid: security.gha.unpinned-action
+      - uses: fgrosse/go-coverage-report@v1
+      # first-party `actions/*` is in scope: GitHub-owned tags are mutable too
+      # ruleid: security.gha.unpinned-action
+      - uses: actions/upload-artifact@v4
+      # branch ref
+      # ruleid: security.gha.unpinned-action
+      - uses: some/action@main
+      # action in a subdirectory of a repo (monorepo layout)
+      # ruleid: security.gha.unpinned-action
+      - uses: github/codeql-action/init@v3
+      # a quoted scalar keeps its quotes in the metavariable, both quote styles
+      # ruleid: security.gha.unpinned-action
+      - uses: "actions/upload-artifact@v4"
+      # ruleid: security.gha.unpinned-action
+      - uses: 'actions/upload-artifact@v4'
+      # a short SHA is not immutable and is not accepted by Actions
+      # ruleid: security.gha.unpinned-action
+      - uses: some/action@abc1234
+      # 39 hex digits: off-by-one on the SHA length must still flag
+      # ruleid: security.gha.unpinned-action
+      - uses: some/action@11bd71901bbe5b1630ceea73d27597364c9af68
+      # inline flow mapping is still a `uses:` key
+      # ruleid: security.gha.unpinned-action
+      - {uses: dorny/test-reporter@v1}
+
+      # --- must NOT flag ---
+      # SHA pin with a trailing version comment (the target end-state)
+      # ok: security.gha.unpinned-action
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      # SHA pin without a comment
+      # ok: security.gha.unpinned-action
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      # quoted SHA pin, with and without a comment
+      # ok: security.gha.unpinned-action
+      - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
+      # ok: security.gha.unpinned-action
+      - uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # v4.2.2
+      # uppercase hex is a valid SHA
+      # ok: security.gha.unpinned-action
+      - uses: actions/checkout@11BD71901BBE5B1630CEEA73D27597364C9AF683
+      # local action: lives in this repo, nothing to pin
+      # ok: security.gha.unpinned-action
+      - uses: ./.github/actions/local
+      # self-repository ref: resolves to the running commit, so pin-equivalent
+      # ok: security.gha.unpinned-action
+      - uses: $/action-dir
+      # container images are a separate ecosystem (pinned by digest)
+      # ok: security.gha.unpinned-action
+      - uses: docker://alpine:3
+      # ok: security.gha.unpinned-action
+      - uses: docker://alpine@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      # temporalio/* is excluded by campaign policy, in every case shape
+      # ok: security.gha.unpinned-action
+      - uses: temporalio/public-actions/sast/opengrep@main
+      # ok: security.gha.unpinned-action
+      - uses: "temporalio/anything@v1"
+      # owner names are case-insensitive on GitHub, so the exclusion is too
+      # ok: security.gha.unpinned-action
+      - uses: Temporalio/anything@v1
+      # a value that merely looks like a ref, under a key that is not `uses:`
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          action: dorny/test-reporter@v1
+      # prose inside a run block must not be parsed as a `uses:` key
+      - run: |
+          echo "example: uses: dorny/test-reporter@v1"
+
+  # --- reusable workflow calls: same trust as an action, same treatment ---
+  calls-unpinned:
+    # ruleid: security.gha.unpinned-action
+    uses: owner/repo/.github/workflows/x.yml@master
+
+  calls-self-repository:
+    # ok: security.gha.unpinned-action
+    uses: $/.github/workflows/reusable.yml
+
+  calls-local:
+    # ok: security.gha.unpinned-action
+    uses: ./.github/workflows/local.yml
+
+  calls-first-party:
+    # ok: security.gha.unpinned-action
+    uses: temporalio/public-actions/.github/workflows/y.yml@main

--- a/sast/opengrep/tests/.github/workflows/gha-unpinned-actions.yaml
+++ b/sast/opengrep/tests/.github/workflows/gha-unpinned-actions.yaml
@@ -87,6 +87,41 @@ jobs:
       - run: |
           echo "example: uses: dorny/test-reporter@v1"
 
+      # --- `uses` in a non-executable position: a user-chosen key that merely
+      # reads `uses`. The value never runs, so reporting it would block a PR
+      # over nothing. Only nested keys are excluded, never siblings, so the
+      # sibling cases below must still flag.
+      # ok: security.gha.unpinned-action
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          uses: owner/repo@v1
+      # flow-mapping form of the same thing
+      # ok: security.gha.unpinned-action
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with: {uses: owner/repo@v1}
+      # an env var named `uses`
+      # ok: security.gha.unpinned-action
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          uses: owner/repo@v1
+
+      # --- siblings must keep flagging: `uses:` next to a `with:`/`env:` block
+      # is the ordinary shape and by far the most common real finding.
+      # ruleid: security.gha.unpinned-action
+      - uses: dorny/test-reporter@v1
+        with:
+          name: results
+      # ruleid: security.gha.unpinned-action
+      - uses: fgrosse/go-coverage-report@v1
+        env:
+          FOO: bar
+      # `uses:` not first in the step mapping, with a trailing `with:` block
+      - name: upload
+        # ruleid: security.gha.unpinned-action
+        uses: actions/upload-artifact@v4
+        with:
+          path: dist
+
   # --- reusable workflow calls: same trust as an action, same treatment ---
   calls-unpinned:
     # ruleid: security.gha.unpinned-action
@@ -103,3 +138,25 @@ jobs:
   calls-first-party:
     # ok: security.gha.unpinned-action
     uses: temporalio/public-actions/.github/workflows/y.yml@main
+
+  # a reusable-workflow call whose `secrets:`/`with:` blocks contain a key named
+  # `uses`. The call itself flags; the nested keys do not.
+  calls-with-nested-uses-keys:
+    # ruleid: security.gha.unpinned-action
+    uses: owner/repo/.github/workflows/z.yml@main
+    with:
+      uses: owner/repo@v1
+    secrets:
+      uses: owner/repo@v1
+
+  # a matrix `include:` entry with a key named `uses`
+  matrixed:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # ok: security.gha.unpinned-action
+          - uses: owner/repo@v1
+    steps:
+      # ruleid: security.gha.unpinned-action
+      - uses: dorny/test-reporter@v2


### PR DESCRIPTION
## Summary

- Adds **`security.gha.unpinned-action` (WARNING)**: flags a `uses:` reference that resolves a mutable ref (tag or branch) instead of a full 40-character commit SHA. Covers step-level actions, subdirectory actions, and **job-level reusable workflow calls**.
- Excluded by campaign policy (SEC-1778), documented inline so they read as deliberate rather than as gaps: `temporalio/*` (first-party, pinned by internal process), local `./` actions, self-repository `$/` refs, and `docker://` images.
- Adds a regression fixture with **35 cases** (16 must-flag, 19 must-not-flag) under the existing harness. **7/7 rules pass** under the pinned Opengrep v1.21.0.
- No changes to existing rules and none to `action.yml` enforcement semantics.

## Why now

**Native enforcement has a permanent gap.** GitHub's org-level [require-SHA-pinning policy](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/) does not cover reusable workflows, which can still be referenced by tag. Treating `owner/repo/.github/workflows/x.yml@ref` exactly like an action is the detective control SEC-2035 calls for, and it stays useful after native policy lands.

**Verified findings decay.** `temporalio/temporal-auto-scaled-workers` was pinned and verified 2026-07-24 (VLN-1627). Within a week new workflows had introduced `dorny/test-reporter@v1`, `actions/upload-artifact@v4`, and `fgrosse/go-coverage-report@v1` unpinned. A maintainer happened to notice the ticket and self-fixed in that repo's PR #104; the campaign would not have caught it, because Verified is terminal.

It was also asked for. Reviewing the pinning PR on `temporalio/temporal` (#10662), a maintainer raised version drift, stale `# vX.Y.Z` comments, and new unpinned actions being added. This is the third of those.

## Rollout impact

The scan already runs on every PR in every `temporalio` repo and is diff-aware, so repos carrying legacy unpinned refs do **not** start failing. Only newly introduced refs are reported.

One correction worth stating plainly: **WARNING does not make this advisory.** `opengrep-report.sh` fails on any new finding regardless of severity, the known gap already documented in #25. WARNING is for consistency with the existing rules, not a softer mode. Diff-awareness is what makes this safe to land org-wide, not the severity.

## What this rule cannot do

It checks ref **shape**, never provenance. A 40-hex imposter or dangling commit passes cleanly, and a lying `# v6.0.3` comment is invisible to it. Those are GHA-T7, and no offline pattern matcher can close them.

So the message routes remediation to `deputy pin --ecosystems github-actions`, which resolves the ref, writes a version comment reflecting the most specific ref that genuinely points at that commit, and verifies branch reachability. The message deliberately does not imply that a pinned ref is a reviewed or verified one. A `deputy pin verify` CI action is the follow-up that closes the provenance half.

There is no `fix:` for the same reason: a correct pin needs a live API lookup plus a reachability check, which a rule file cannot perform.

## Validation

Proven against both engines, not by inspection. Two behaviours are invisible by reading and are now pinned by fixture cases:

1. **A quoted scalar binds with its quotes.** `$ACTION` for `uses: "actions/checkout@v4"` is `"actions/checkout@v4"`. A plainly `^`-anchored regex silently misses every quoted ref, and there are 30+ in the org today.
2. **A trailing version comment is not part of the scalar**, so `@<40-hex>$` is a sound end-anchor.

There is also a subtle trap the fixture locks down: with `^["']?(?!temporalio/)` the engine backtracks to the pre-quote position and the lookahead passes, so `"temporalio/x@v1"` gets reported. The optional quote has to live *inside* the negative lookahead. That false positive occurred during development.

Precision was then measured on real repos rather than asserted. Across 73 `temporalio` clones (448 workflow and action files, 2,022 `uses:` values):

| Class | Count | Reported |
|---|---|---|
| mutable ref | 832 | all |
| SHA-pinned (40 hex) | 668 | none |
| `temporalio/*` | 296 | none |
| local `./` | 225 | none |
| `docker://` | 1 | none |

**Zero disagreements** against an independent classifier: no false positives, no false negatives. The 158 distinct refs reported include the awkward shapes, all correctly: `dtolnay/rust-toolchain@stable` (branch-only action), `securego/gosec@master`, `anthropics/claude-code-action@beta`, `geomys/sandboxed-step@v1.2.0` (immutable releases still want a pin), and three reusable-workflow refs.

Caveat: no `$/` refs exist in the wild yet, since [the syntax is a day old](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/). That case rests on fixture coverage alone.

Reproduce:

```bash
docker build -t opengrep-rules sast/opengrep/tests
docker run --rm -v "$PWD:/work" opengrep-rules
```

## Companion rule: skipped, with reason

A `security.gha.self-reference-mutable` rule (flag `temporalio/myrepo/...@main` *inside* `temporalio/myrepo` and recommend `$/`) is **not expressible** and is not included. Opengrep rules have no scan-time repository identity. The only expressible approximation is "any `temporalio/*` at a mutable ref", which false-positives on the 296 legitimate cross-repo refs above and would actively break things: recommending `$/` for `temporalio/public-actions/sast/opengrep@main` called from another repo resolves to *that* repo, not `public-actions`.

The illustration is in this repo. [`.github/workflows/opengrep.yml`](.github/workflows/opengrep.yml) uses `temporalio/public-actions/sast/opengrep@main` inside `temporalio/public-actions` itself, genuinely `$/`-able and genuinely indistinguishable from the cross-repo case by a static rule. Shipping an approximation would be worse than shipping nothing.

## Related

- Ticket: SEC-2085. Epic: SEC-2035 (GHA Pinning Org-level Enforcement). Campaign: SEC-1778
- Campaign-side counterpart: temporalio/camper#43 detects drift on the default branch; this prevents it at PR time. Defense in depth, not duplication.
- Sibling PR: the `deprecated-actions` autofix emitted an unpinned ref, fixed separately under SEC-2086 (independent change, no dependency between the two).
- Threat model: `security-models` `gha-pipeline-integrity.md` GHA-T4 (tag mutability), GHA-T7 (imposter commits)
