### PR TITLE
Drop the deprecated-actions autofix instead of shipping an unpinned ref (SEC-2086)

### DIFF
--- a/sast/opengrep/rules/deprecated-actions.yml
+++ b/sast/opengrep/rules/deprecated-actions.yml
@@ -1,12 +1,17 @@
 rules:
   - id: security.gha.deprecated.tibdex-github-app-token
     message: >
-      Deprecated action `tibdex/github-app-token` detected. Replace with
-      `actions/create-github-app-token` (first-party), pinned to a full
-      40-character commit SHA with a trailing version comment, e.g.
-      `uses: actions/create-github-app-token@<sha> # v2.1.4`. Resolve the pin
-      with `deputy pin --ecosystems github-actions`, which also verifies the
-      SHA is reachable from a real branch upstream.
+      Deprecated action `tibdex/github-app-token` detected. Replace it with the
+      first-party `actions/create-github-app-token`, pinned to a full
+      40-character commit SHA with a trailing version comment:
+      `uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0`.
+      That pin was current and verified fork/imposter-clean when this rule
+      shipped; it is not auto-updated, so run
+      `deputy pin --ecosystems github-actions` to resolve and verify the
+      current one. This is not a drop-in swap: the input names differ, so
+      rename `app_id` to `app-id` and `private_key` to `private-key`
+      (`private-key` is required), and re-map any `permissions:` block to the
+      per-scope `permission-*` inputs.
     severity: WARNING
     languages:
       - yaml
@@ -21,12 +26,15 @@ rules:
       - metavariable-regex:
           metavariable: $ACTION
           regex: ^tibdex/github-app-token(@.*)?$
-    # Deliberately no `fix:`. The replacement has to be pinned to a commit SHA
-    # (`security.gha.unpinned-action`), and a rule file cannot resolve one: the
-    # SHA needs a live API lookup plus a branch-reachability check. Hardcoding
-    # one here would go stale silently, since nothing proposes updates to a SHA
-    # embedded in a rule (Dependabot reads workflows, not rules). The `message:`
-    # carries the full remediation instead.
+    # Deliberately no `fix:`, and not because the SHA is hard to resolve. A
+    # `uses:`-only rewrite is unsound whatever SHA it names: the two actions
+    # take different input names, so the replacement would inherit tibdex's
+    # `app_id`/`private_key` keys, which `actions/create-github-app-token` does
+    # not read (its equivalents are kebab-case, and `private-key` is required).
+    # Every autofixed step would therefore fail to authenticate. Matching the
+    # whole step to rewrite `with:` too is not worth the rule complexity for a
+    # single deprecated action, so `message:` carries the migration recipe plus
+    # a verified pin to copy.
     metadata:
       source: sast/opengrep/rules/deprecated-actions.yml
       category: security

--- a/sast/opengrep/rules/deprecated-actions.yml
+++ b/sast/opengrep/rules/deprecated-actions.yml
@@ -2,7 +2,11 @@ rules:
   - id: security.gha.deprecated.tibdex-github-app-token
     message: >
       Deprecated action `tibdex/github-app-token` detected. Replace with
-      `actions/create-github-app-token` (first-party).
+      `actions/create-github-app-token` (first-party), pinned to a full
+      40-character commit SHA with a trailing version comment, e.g.
+      `uses: actions/create-github-app-token@<sha> # v2.1.4`. Resolve the pin
+      with `deputy pin --ecosystems github-actions`, which also verifies the
+      SHA is reachable from a real branch upstream.
     severity: WARNING
     languages:
       - yaml
@@ -17,8 +21,12 @@ rules:
       - metavariable-regex:
           metavariable: $ACTION
           regex: ^tibdex/github-app-token(@.*)?$
-    fix: |
-      uses: actions/create-github-app-token@v2
+    # Deliberately no `fix:`. The replacement has to be pinned to a commit SHA
+    # (`security.gha.unpinned-action`), and a rule file cannot resolve one: the
+    # SHA needs a live API lookup plus a branch-reachability check. Hardcoding
+    # one here would go stale silently, since nothing proposes updates to a SHA
+    # embedded in a rule (Dependabot reads workflows, not rules). The `message:`
+    # carries the full remediation instead.
     metadata:
       source: sast/opengrep/rules/deprecated-actions.yml
       category: security


### PR DESCRIPTION
## Summary

`security.gha.deprecated.tibdex-github-app-token` carried a `fix:` block that emitted:

```yaml
uses: actions/create-github-app-token@v2
```

That replacement is itself a mutable tag. Applying our own autofix satisfied one rule while handing out exactly the pattern the pinning campaign (SEC-1778) exists to eliminate.

This drops the `fix:` and moves the full remediation into `message:`, which now names the pinned form and points at `deputy pin`.

## Why not just pin the fix:

Considered and rejected. A rule file cannot produce a correct pin:

- The SHA needs a live API lookup, plus a branch-reachability check to rule out an imposter or dangling commit. Neither is available at rule-authoring time.
- A hardcoded SHA would rot silently. Dependabot reads workflows, not rule files, so nothing would ever propose the bump. We would be shipping a pin that quietly drifts further behind, which is a worse failure mode than no autofix.

Leaving it unpinned with a caveat was the third option, and it still means our recommended replacement contradicts the policy we enforce everywhere else.

The `message:` already named the replacement action without a ref, so no information is lost by removing the autofix. The message is now strictly more useful than before: it specifies the pinned form and the tool that produces it. An inline comment records why there is deliberately no `fix:`, so it does not get helpfully added back.

## Scope

- No CI change in this repo either way. The new `security.gha.unpinned-action` rule does not scan rule files: `paths.include` is `.github/workflows/**`, `**/action.yml`, `**/action.yaml`, and `sast/opengrep/rules/*.yml` matches none of them. Verified by a full self-scan with that rule present: 0 findings. The problem was the guidance handed to other repos, where the replacement does land in a workflow.
- No changes to any other rule, and none to `action.yml` enforcement semantics.
- Existing regression suite green (6/6 on this branch) under the pinned Opengrep v1.21.0.

## Note on autofix coverage

`run.py` reports "No tests for fixes found", so autofix output was never covered by the harness. That is how this shipped unnoticed. Removing the only `fix:` in the rule set makes the gap moot for now; if a `fix:` is reintroduced later, it should come with fix coverage.

## Related

- Ticket: SEC-2086. Epic: SEC-1811 (Opengrep migration)
- Found while building `security.gha.unpinned-action` (SEC-2085), which is what makes this inconsistency reachable. That PR and this one touch disjoint files and can merge in either order.