### PR TITLE
Update govulncheck to v1.7.0

### DIFF
--- a/golang/govulncheck/README.md
+++ b/golang/govulncheck/README.md
@@ -21,7 +21,7 @@ That's it. On `pull_request` and `merge_group` events, `base-sha` is automatical
 
 | Input | Default | Description |
 |---|---|---|
-| `govulncheck-version` | `v1.1.4` | Version of govulncheck to install |
+| `govulncheck-version` | `v1.7.0` | Version of govulncheck to install |
 | `base-sha` | Auto-detected | Base branch SHA for differential comparison. Override to compare against a specific commit. |
 
 ## Outputs

--- a/golang/govulncheck/action.yml
+++ b/golang/govulncheck/action.yml
@@ -4,7 +4,7 @@ inputs:
   govulncheck-version:
     description: 'Version of govulncheck to use'
     required: false
-    default: 'v1.1.4'
+    default: 'v1.7.0'
   base-sha:
     description: >-
       Base branch SHA for differential comparison. Automatically detected on

--- a/golang/govulncheck/scripts/govulncheck-report.sh
+++ b/golang/govulncheck/scripts/govulncheck-report.sh
@@ -10,7 +10,7 @@
 #
 # Local testing:
 #   # Generate sample data:
-#   go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 -json ./... > /tmp/pr-vulns.json 2>/dev/null || true
+#   go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 -json ./... > /tmp/pr-vulns.json 2>/dev/null || true
 #   # Compare two scans:
 #   ./govulncheck-report.sh /tmp/pr-vulns.json /tmp/base-vulns.json
 #


### PR DESCRIPTION
Update the default govulncheck version from v1.1.4 to v1.7.0 so the action can scan Go 1.27 programs without an SSA panic.
