### PR TITLE
govulncheck: add an ignore file and a reachability threshold

### DIFF
--- a/.github/workflows/test-govulncheck-action.yml
+++ b/.github/workflows/test-govulncheck-action.yml
@@ -1,8 +1,9 @@
 name: govulncheck action tests
 
 # Regression tests for the govulncheck composite action's reporting logic —
-# specifically ignore-list parsing and its effect on the new/pre-existing/
-# ignored buckets. Pure bash + jq + awk, no Go toolchain or govulncheck install.
+# ignore-list parsing and the fail-on reachability threshold, and how each
+# affects the new/pre-existing/ignored buckets and the exit code. Pure bash +
+# jq + awk over crafted scan JSON, no Go toolchain or govulncheck install.
 
 on:
   pull_request:
@@ -17,14 +18,17 @@ permissions:
   contents: read
 
 jobs:
-  ignorelist-tests:
-    name: govulncheck/ignorelist-tests
+  report-tests:
+    name: govulncheck/report-tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # Runs under mawk, the default awk on Ubuntu runners. The parser is
-      # written to the common subset of mawk, gawk, and BSD awk, so this is
-      # the coverage that catches an accidental gawk-ism.
+      # Runs under mawk, the default awk on Ubuntu runners. The ignore-file
+      # parser is written to the common subset of mawk, gawk, and BSD awk, so
+      # this is the coverage that catches an accidental gawk-ism.
       - name: Run ignore-list tests
         run: bash golang/govulncheck/tests/ignorelist-test.sh
+
+      - name: Run fail-on threshold tests
+        run: bash golang/govulncheck/tests/fail-on-test.sh

--- a/.github/workflows/test-govulncheck-action.yml
+++ b/.github/workflows/test-govulncheck-action.yml
@@ -1,0 +1,30 @@
+name: govulncheck action tests
+
+# Regression tests for the govulncheck composite action's reporting logic —
+# specifically ignore-list parsing and its effect on the new/pre-existing/
+# ignored buckets. Pure bash + jq + awk, no Go toolchain or govulncheck install.
+
+on:
+  pull_request:
+    paths:
+      - 'golang/govulncheck/scripts/**'
+      - 'golang/govulncheck/action.yml'
+      - 'golang/govulncheck/tests/**'
+      - '.github/workflows/test-govulncheck-action.yml'
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  ignorelist-tests:
+    name: govulncheck/ignorelist-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Runs under mawk, the default awk on Ubuntu runners. The parser is
+      # written to the common subset of mawk, gawk, and BSD awk, so this is
+      # the coverage that catches an accidental gawk-ism.
+      - name: Run ignore-list tests
+        run: bash golang/govulncheck/tests/ignorelist-test.sh

--- a/golang/govulncheck/.govulncheck-ignore.example
+++ b/golang/govulncheck/.govulncheck-ignore.example
@@ -19,11 +19,19 @@
 #   Record why the risk is accepted and what would let you remove the entry.
 #   Reviewers see this text in the job summary, and the action warns when an
 #   entry no longer matches anything so stale suppressions get cleaned up.
+#
+#   Before adding an entry for something your code never calls, consider the
+#   fail-on input instead. `fail-on: symbol` excuses every unreachable finding
+#   at once, with nothing to maintain per vulnerability. Reach for this file
+#   when you need to accept a specific risk, not a whole category.
 
 # golang.org/x/crypto/openpgp is unmaintained upstream with no fixed version,
 # so this can never be resolved by a dependency bump. govulncheck reports it at
 # module level only ("modules you require"), meaning nothing in our build
 # imports the package. Remove once the transitive requirement is gone.
+#
+# An entry is only needed here at fail-on: module. At fail-on: package or
+# symbol this finding is already below the threshold.
 GO-2026-5932
 
 # Reachable, but the affected code path only parses release manifests we

--- a/golang/govulncheck/.govulncheck-ignore.example
+++ b/golang/govulncheck/.govulncheck-ignore.example
@@ -1,0 +1,31 @@
+# Example .govulncheck-ignore
+#
+# Copy this to the root of a Go repository as `.govulncheck-ignore` to stop
+# specific vulnerabilities from failing the govulncheck action. Every other
+# vulnerability keeps failing the check as normal.
+#
+# Format
+#   - One Go vulnerability ID per line: GO-YYYY-NNNN
+#   - Blank lines are skipped
+#   - Everything after '#' is a comment
+#   - The comment block directly above an entry, or a trailing comment on the
+#     entry line, becomes that entry's reason and is shown in the job summary
+#   - A blank line separates a comment block from the entry below it, so a file
+#     header is not mistaken for a justification
+#   - Anything else fails the job: a misparsed ignore file must not silently
+#     weaken the check
+#
+# Guidance
+#   Record why the risk is accepted and what would let you remove the entry.
+#   Reviewers see this text in the job summary, and the action warns when an
+#   entry no longer matches anything so stale suppressions get cleaned up.
+
+# golang.org/x/crypto/openpgp is unmaintained upstream with no fixed version,
+# so this can never be resolved by a dependency bump. govulncheck reports it at
+# module level only ("modules you require"), meaning nothing in our build
+# imports the package. Remove once the transitive requirement is gone.
+GO-2026-5932
+
+# Reachable, but the affected code path only parses release manifests we
+# produce ourselves. Tracked in SEC-1234; drop this once foo/bar v2 lands.
+GO-2025-1234

--- a/golang/govulncheck/README.md
+++ b/golang/govulncheck/README.md
@@ -24,6 +24,7 @@ That's it. On `pull_request` and `merge_group` events, `base-sha` is automatical
 | `govulncheck-version` | `v1.1.4` | Version of govulncheck to install |
 | `base-sha` | Auto-detected | Base branch SHA for differential comparison. Override to compare against a specific commit. |
 | `ignore-file` | `.govulncheck-ignore` if present | Path to a file listing vulnerabilities that must not fail the check. An explicitly set path that does not exist is an error. |
+| `fail-on` | `module` | Lowest scan level that may fail the check: `module`, `package`, or `symbol`. See [Reachability](#reachability). |
 
 ## Outputs
 
@@ -32,6 +33,7 @@ That's it. On `pull_request` and `merge_group` events, `base-sha` is automatical
 | `new-count` | Number of newly introduced vulnerabilities |
 | `has-new-vulns` | `true` if new vulnerabilities were found, `false` otherwise |
 | `ignored-count` | Number of vulnerabilities suppressed by the ignore file |
+| `below-threshold-count` | Number of vulnerabilities reported but below the `fail-on` threshold |
 
 ### Using outputs
 
@@ -42,6 +44,30 @@ That's it. On `pull_request` and `merge_group` events, `base-sha` is automatical
 - if: steps.vulncheck.outputs.has-new-vulns == 'true'
   run: echo "${{ steps.vulncheck.outputs.new-count }} new vulnerabilities found"
 ```
+
+## Reachability
+
+govulncheck reports a vulnerability at one of three levels, depending on how deeply your code touches it:
+
+| Level | Meaning | govulncheck's own wording |
+|---|---|---|
+| `module` | The module is in your build graph | "in modules you require... your code doesn't appear to call these" |
+| `package` | The vulnerable package is imported | "in packages you import" |
+| `symbol` | Your code calls the vulnerable symbol | "Your code is affected by N vulnerabilities" |
+
+By default this action fails on **any** level, including findings govulncheck itself classifies as not affecting your code. `fail-on` narrows that:
+
+```yaml
+- uses: temporalio/public-actions/golang/govulncheck@main
+  with:
+    fail-on: symbol   # only block when your code actually calls the vulnerable symbol
+```
+
+Findings below the threshold don't vanish. They get their own job-summary section so the exposure stays visible, they just don't block.
+
+**When this matters.** [GO-2026-5932](https://pkg.go.dev/vuln/GO-2026-5932) covers `golang.org/x/crypto/openpgp` at every version. Repos that only require `golang.org/x/crypto` transitively, without importing `openpgp`, hit a module-level finding with no fix and no reachable code. `fail-on: symbol` resolves it with no ignore entry to maintain.
+
+**Choosing a level.** `symbol` matches what govulncheck's text output treats as actionable, and is the tightest signal-to-noise. It is also the loosest gate: a vulnerability becomes blocking only once something calls it, so a dependency that adds a vulnerable call path in a later release won't be flagged until that path is reachable from your code. `module` is the most conservative and stays the default. Note the analysis is static, so `symbol` can miss reflection- and codegen-driven call paths.
 
 ## Ignoring a vulnerability
 
@@ -72,6 +98,7 @@ The action writes a GitHub job summary with:
 - **Resolved vulnerabilities** — were on the base branch but are now fixed
 - **Pre-existing vulnerabilities** — present on both branches (does not block)
 - **Ignored vulnerabilities** — matched an ignore-file entry, shown with the reason (does not block)
+- **Below the threshold** — reported at a scan level under `fail-on` (does not block)
 
 Each vulnerability links to [pkg.go.dev/vuln](https://pkg.go.dev/vuln/) with the affected module, current version, and fix version.
 
@@ -86,4 +113,7 @@ Reporting logic is covered by pure bash/jq tests that craft scan JSON directly, 
 
 ```bash
 bash golang/govulncheck/tests/ignorelist-test.sh
+bash golang/govulncheck/tests/fail-on-test.sh
 ```
+
+Shared fixtures and assertions live in `tests/lib.sh`.

--- a/golang/govulncheck/README.md
+++ b/golang/govulncheck/README.md
@@ -23,6 +23,7 @@ That's it. On `pull_request` and `merge_group` events, `base-sha` is automatical
 |---|---|---|
 | `govulncheck-version` | `v1.1.4` | Version of govulncheck to install |
 | `base-sha` | Auto-detected | Base branch SHA for differential comparison. Override to compare against a specific commit. |
+| `ignore-file` | `.govulncheck-ignore` if present | Path to a file listing vulnerabilities that must not fail the check. An explicitly set path that does not exist is an error. |
 
 ## Outputs
 
@@ -30,6 +31,7 @@ That's it. On `pull_request` and `merge_group` events, `base-sha` is automatical
 |---|---|
 | `new-count` | Number of newly introduced vulnerabilities |
 | `has-new-vulns` | `true` if new vulnerabilities were found, `false` otherwise |
+| `ignored-count` | Number of vulnerabilities suppressed by the ignore file |
 
 ### Using outputs
 
@@ -41,12 +43,35 @@ That's it. On `pull_request` and `merge_group` events, `base-sha` is automatical
   run: echo "${{ steps.vulncheck.outputs.new-count }} new vulnerabilities found"
 ```
 
+## Ignoring a vulnerability
+
+Some findings can't be fixed by upgrading. The clearest case is a package that upstream has abandoned with no fixed version, such as [GO-2026-5932](https://pkg.go.dev/vuln/GO-2026-5932) (`golang.org/x/crypto/openpgp`), where no dependency bump will ever clear the finding.
+
+Add a `.govulncheck-ignore` file to the repo root:
+
+```
+# golang.org/x/crypto/openpgp is unmaintained upstream with no fixed version.
+# Reported at module level only — nothing in our build imports the package.
+GO-2026-5932
+
+GO-2025-1234  # reachable but low risk; tracked in SEC-1234
+```
+
+- One `GO-YYYY-NNNN` per line. Blank lines are skipped, `#` starts a comment.
+- The comment block directly above an entry, or a trailing comment on the entry line, is captured as that entry's **reason** and rendered in the job summary. A blank line detaches a comment block from the entry below it, so a file header isn't mistaken for a justification.
+- A malformed line fails the job. An ignore file that silently misparses would weaken the check without anyone noticing.
+
+See [`.govulncheck-ignore.example`](.govulncheck-ignore.example) for a fuller template.
+
+**Guardrails.** The ignore file is read from the head tree, so a PR can add an entry and unblock itself. That's necessary (otherwise there'd be no way to land a suppression), but it means the file is the security boundary: add it to `CODEOWNERS` if suppressions need review. The action also warns when an entry no longer matches anything in the scan, so stale suppressions surface instead of accumulating.
+
 ## Job summary
 
 The action writes a GitHub job summary with:
 - **New vulnerabilities** — not present on the base branch (blocks the PR)
 - **Resolved vulnerabilities** — were on the base branch but are now fixed
 - **Pre-existing vulnerabilities** — present on both branches (does not block)
+- **Ignored vulnerabilities** — matched an ignore-file entry, shown with the reason (does not block)
 
 Each vulnerability links to [pkg.go.dev/vuln](https://pkg.go.dev/vuln/) with the affected module, current version, and fix version.
 
@@ -54,3 +79,11 @@ Each vulnerability links to [pkg.go.dev/vuln](https://pkg.go.dev/vuln/) with the
 
 - Go must be set up before calling this action (e.g., via [actions/setup-go](https://github.com/actions/setup-go))
 - `jq` must be available on the runner (pre-installed on GitHub-hosted runners)
+
+## Tests
+
+Reporting logic is covered by pure bash/jq tests that craft scan JSON directly, with no govulncheck install needed:
+
+```bash
+bash golang/govulncheck/tests/ignorelist-test.sh
+```

--- a/golang/govulncheck/action.yml
+++ b/golang/govulncheck/action.yml
@@ -12,6 +12,14 @@ inputs:
       findings are treated as new. Override to compare against a specific commit.
     required: false
     default: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+  ignore-file:
+    description: >-
+      Path to a file listing vulnerability IDs that must not fail the check,
+      one GO-xxxx-xxxx per line, with '#' comments used to record why. When
+      empty, .govulncheck-ignore at the repo root is used if it exists.
+      An explicitly set path that does not exist is an error.
+    required: false
+    default: ''
 outputs:
   new-count:
     description: 'Number of newly introduced vulnerabilities'
@@ -19,6 +27,9 @@ outputs:
   has-new-vulns:
     description: 'Whether new vulnerabilities were found (true/false)'
     value: ${{ steps.report.outputs.has-new-vulns }}
+  ignored-count:
+    description: 'Number of vulnerabilities suppressed by the ignore file'
+    value: ${{ steps.report.outputs.ignored-count }}
 runs:
   using: "composite"
   steps:
@@ -81,7 +92,22 @@ runs:
     - name: Compare and report
       id: report
       shell: bash
+      env:
+        IGNORE_FILE: ${{ inputs.ignore-file }}
       run: |
         # Ensure base scan file exists even if the base scan step was skipped or failed.
         touch "${RUNNER_TEMP}/base-vulns.json"
-        "$GITHUB_ACTION_PATH/scripts/govulncheck-report.sh" "${RUNNER_TEMP}/pr-vulns.json" "${RUNNER_TEMP}/base-vulns.json"
+
+        # Resolve the ignore file. An explicitly configured path is passed
+        # through as-is so the report script fails loudly on a typo; the
+        # default is opt-in by convention and silently absent when unused.
+        # Note this reads the head tree — the base scan step restores HEAD
+        # before this runs, so a PR's own ignore entries apply to itself.
+        if [ -z "$IGNORE_FILE" ] && [ -f .govulncheck-ignore ]; then
+          IGNORE_FILE=.govulncheck-ignore
+        fi
+
+        "$GITHUB_ACTION_PATH/scripts/govulncheck-report.sh" \
+          "${RUNNER_TEMP}/pr-vulns.json" \
+          "${RUNNER_TEMP}/base-vulns.json" \
+          "$IGNORE_FILE"

--- a/golang/govulncheck/action.yml
+++ b/golang/govulncheck/action.yml
@@ -20,6 +20,16 @@ inputs:
       An explicitly set path that does not exist is an error.
     required: false
     default: ''
+  fail-on:
+    description: >-
+      Lowest govulncheck scan level that may fail the check. 'module' (the
+      default) fails on anything in the module graph. 'package' requires the
+      vulnerable package to be imported. 'symbol' requires your code to
+      actually call the vulnerable symbol, matching what govulncheck's own
+      output counts as "Your code is affected by". Findings below the
+      threshold are still reported in the job summary, but never block.
+    required: false
+    default: 'module'
 outputs:
   new-count:
     description: 'Number of newly introduced vulnerabilities'
@@ -30,6 +40,9 @@ outputs:
   ignored-count:
     description: 'Number of vulnerabilities suppressed by the ignore file'
     value: ${{ steps.report.outputs.ignored-count }}
+  below-threshold-count:
+    description: 'Number of vulnerabilities reported but below the fail-on threshold'
+    value: ${{ steps.report.outputs.below-threshold-count }}
 runs:
   using: "composite"
   steps:
@@ -94,6 +107,7 @@ runs:
       shell: bash
       env:
         IGNORE_FILE: ${{ inputs.ignore-file }}
+        FAIL_ON: ${{ inputs.fail-on }}
       run: |
         # Ensure base scan file exists even if the base scan step was skipped or failed.
         touch "${RUNNER_TEMP}/base-vulns.json"
@@ -110,4 +124,5 @@ runs:
         "$GITHUB_ACTION_PATH/scripts/govulncheck-report.sh" \
           "${RUNNER_TEMP}/pr-vulns.json" \
           "${RUNNER_TEMP}/base-vulns.json" \
-          "$IGNORE_FILE"
+          "$IGNORE_FILE" \
+          "$FAIL_ON"

--- a/golang/govulncheck/scripts/govulncheck-report.sh
+++ b/golang/govulncheck/scripts/govulncheck-report.sh
@@ -3,7 +3,14 @@
 # then write a GitHub job summary with the findings.
 #
 # Usage:
-#   govulncheck-report.sh <pr-vulns.json> <base-vulns.json> [ignore-file]
+#   govulncheck-report.sh <pr-vulns.json> <base-vulns.json> [ignore-file] [fail-on]
+#
+# fail-on selects the lowest govulncheck scan level that may fail the check:
+#   module  (default) any vulnerability in the module graph, reachable or not
+#   package           only if the vulnerable package is imported
+#   symbol            only if your code actually calls the vulnerable symbol
+# Findings below the threshold are still reported, in their own job-summary
+# section, but never block. See extract_ids() for how levels are derived.
 #
 # Environment variables (set automatically by GitHub Actions):
 #   GITHUB_STEP_SUMMARY — path to the job summary file (falls back to stdout)
@@ -74,14 +81,52 @@ validate_format() {
   fi
 }
 
-# Extract unique OSV vulnerability IDs from govulncheck's JSON stream.
-# Reads "finding" objects, which link source code to a vulnerability.
+# Extract unique OSV vulnerability IDs from govulncheck's JSON stream, keeping
+# only those that reach at least the given scan level.
+#
+# govulncheck emits findings at three levels, distinguished by how much of
+# trace[0] is populated (see the Frame docs linked at the top of this file):
+#
+#   1 module   module + version only  — the module is in the build graph
+#   2 package  + package              — the vulnerable package is imported
+#   3 symbol   + function             — your code calls the vulnerable symbol
+#
+# One vulnerability can produce findings at several levels, so each ID is
+# reduced to its highest level before the threshold is applied. Level 3 is what
+# govulncheck's own text output counts under "Your code is affected by"; levels
+# 1 and 2 are what it reports as "your code doesn't appear to call these".
 extract_ids() {
   local json_file=$1
-  jq -r 'select(.finding) | .finding.osv // empty' "$json_file" 2>/dev/null \
+  local min_level=$2
+  jq -r --argjson min "$min_level" -s '
+    [ .[]
+      | select(.finding)
+      | .finding
+      | { osv,
+          level: (
+            if   (.trace[0].function // "") != "" then 3
+            elif (.trace[0].package  // "") != "" then 2
+            else 1
+            end) } ]
+    | group_by(.osv)
+    | map(select((map(.level) | max) >= $min))
+    | .[][0].osv
+  ' "$json_file" 2>/dev/null \
     | sort -u \
     | grep . \
     || true  # grep exits 1 when no matches — don't let set -e kill us
+}
+
+# Translate a fail-on level name into its numeric rank. Exits non-zero on an
+# unrecognized name so a typo fails the job instead of silently picking a
+# threshold nobody intended.
+level_rank() {
+  case "$1" in
+    module)  echo 1 ;;
+    package) echo 2 ;;
+    symbol)  echo 3 ;;
+    *)       return 1 ;;
+  esac
 }
 
 # Count non-empty lines in a string. Returns 0 for empty input.
@@ -275,7 +320,8 @@ diff_vuln_ids() {
 # Render the full GitHub job summary. Reads global state set by main():
 #   NEW_IDS, RESOLVED_IDS, EXISTING_IDS — newline-separated vuln ID lists
 #   IGNORED_ENTRIES — TAB-separated "ID<TAB>reason" lines for suppressed vulns
-#   new_count, resolved_count, existing_count, ignored_count — integer counts
+#   BELOW_IDS — vulns under the fail-on threshold (reported, never blocking)
+#   new_count, resolved_count, existing_count, ignored_count, below_count
 # Falls back to stdout when GITHUB_STEP_SUMMARY is unset (local testing).
 write_summary() {
   local details_file=$1
@@ -331,6 +377,23 @@ write_summary() {
       ignored_table "$IGNORED_ENTRIES" "$details_file"
       echo ""
       echo "</details>"
+      echo ""
+    fi
+
+    if [ "$below_count" -gt 0 ]; then
+      echo "### :information_source: Below the \`${FAIL_ON_LEVEL}\` threshold ($below_count)"
+      echo ""
+      case "$FAIL_ON_LEVEL" in
+        package) echo "Present in the module graph, but the vulnerable package is not imported." ;;
+        symbol)  echo "Present in the build, but your code does not call the vulnerable symbols." ;;
+      esac
+      echo "Reported for visibility; these do not block the PR."
+      echo ""
+      echo "<details><summary>Click to expand</summary>"
+      echo ""
+      vuln_table "$BELOW_IDS" "$details_file"
+      echo ""
+      echo "</details>"
     fi
   } >> "$summary_file"
 }
@@ -344,14 +407,16 @@ write_summary() {
 DETAILS_FILE=$(mktemp)
 trap 'rm -f "$DETAILS_FILE"' EXIT
 
-# Ignore-list state, declared here so write_summary can read it under `set -u`
-# even when no ignore file is in play.
+# Ignore-list and threshold state, declared here so write_summary can read it
+# under `set -u` even when no ignore file or non-default threshold is in play.
 IGNORED_ENTRIES=""
 IGNORE_FILE_PATH=""
+BELOW_IDS=""
+FAIL_ON_LEVEL="module"
 
 # Algorithm:
 #   1. Validate the PR scan output format (warn if protocol changed).
-#   2. Extract vuln IDs from both scans → sorted, unique, newline-separated.
+#   2. Extract vuln IDs at or above the fail-on threshold from both scans.
 #   3. Parse the ignore file (if any) into IDs + reasons.
 #   4. Set-diff the two ID lists → new / resolved / pre-existing.
 #   5. Subtract ignored IDs from every bucket; report them separately.
@@ -359,21 +424,38 @@ IGNORE_FILE_PATH=""
 #   7. Render a GitHub job summary with markdown tables.
 #   8. Expose counts via GITHUB_OUTPUT for downstream workflow steps.
 #   9. Exit 1 if any non-ignored new vulns were introduced; 0 otherwise.
+USAGE="Usage: govulncheck-report.sh <pr-vulns.json> <base-vulns.json> [ignore-file] [fail-on]"
 main() {
-  local pr_json="${1:?Usage: govulncheck-report.sh <pr-vulns.json> <base-vulns.json> [ignore-file]}"
-  local base_json="${2:?Usage: govulncheck-report.sh <pr-vulns.json> <base-vulns.json> [ignore-file]}"
+  local pr_json="${1:?$USAGE}"
+  local base_json="${2:?$USAGE}"
   local ignore_file="${3:-}"
+  FAIL_ON_LEVEL="${4:-module}"
 
   if ! command -v jq &>/dev/null; then
     echo "::error::jq is required but not installed — use a GitHub-hosted runner or install jq"
     exit 1
   fi
 
+  local min_level
+  if ! min_level=$(level_rank "$FAIL_ON_LEVEL"); then
+    echo "::error::invalid fail-on level '${FAIL_ON_LEVEL}' — expected one of: module, package, symbol"
+    exit 1
+  fi
+
   validate_format "$pr_json"
 
-  # Step 2: extract vuln IDs from both scans.
-  PR_IDS=$(extract_ids "$pr_json")
-  BASE_IDS=$(extract_ids "$base_json")
+  # Step 2: extract vuln IDs from both scans, keeping only those at or above
+  # the threshold. Everything below it is still collected so the summary can
+  # report it without blocking.
+  PR_IDS=$(extract_ids "$pr_json" "$min_level")
+  BASE_IDS=$(extract_ids "$base_json" "$min_level")
+
+  # Every ID in the PR scan regardless of level. Used for the below-threshold
+  # section, and so that ignore entries covering a below-threshold finding are
+  # not misreported as stale.
+  local pr_all_ids
+  pr_all_ids=$(extract_ids "$pr_json" 1)
+  BELOW_IDS=$(filter_ids "$pr_all_ids" "$PR_IDS")
 
   # Step 3: parse the ignore file. It is read from the head tree, so a PR can
   # add a suppression and have it apply to itself — required to unblock a PR at
@@ -415,13 +497,16 @@ main() {
     NEW_IDS=$(filter_ids "$NEW_IDS" "$ignored_ids")
     RESOLVED_IDS=$(filter_ids "$RESOLVED_IDS" "$ignored_ids")
     EXISTING_IDS=$(filter_ids "$EXISTING_IDS" "$ignored_ids")
+    # An explicit ignore wins over the threshold classification, so the entry
+    # and its reason are what a reviewer sees rather than a bare listing.
+    BELOW_IDS=$(filter_ids "$BELOW_IDS" "$ignored_ids")
 
-    # Keep only the entries whose ID actually appeared in this scan.
+    # Keep only the entries whose ID actually appeared in this scan, at any level.
     IGNORED_ENTRIES=$(awk -F'\t' 'NR==FNR { present[$0]=1; next } present[$1]' \
-      <(echo "$PR_IDS") <(echo "$ignore_entries") || true)
+      <(echo "$pr_all_ids") <(echo "$ignore_entries") || true)
 
     local stale stale_count
-    stale=$(comm -23 <(echo "$ignored_ids") <(echo "$PR_IDS") | grep . || true)
+    stale=$(comm -23 <(echo "$ignored_ids") <(echo "$pr_all_ids") | grep . || true)
     stale_count=$(count_lines "$stale")
     if [ "$stale_count" -gt 0 ]; then
       echo "::warning::${IGNORE_FILE_PATH} lists ${stale_count} $([ "$stale_count" -eq 1 ] && echo "vulnerability" || echo "vulnerabilities") not present in this scan — consider removing: $(tr '\n' ' ' <<< "$stale")"
@@ -432,6 +517,7 @@ main() {
   resolved_count=$(count_lines "$RESOLVED_IDS")
   existing_count=$(count_lines "$EXISTING_IDS")
   ignored_count=$(count_lines "${IGNORED_ENTRIES:-}")
+  below_count=$(count_lines "$BELOW_IDS")
 
   # Emit an annotation visible in the PR checks summary.
   if [ "$new_count" -gt 0 ]; then
@@ -455,6 +541,7 @@ main() {
     echo "new-count=${new_count}" >> "$GITHUB_OUTPUT"
     echo "has-new-vulns=$([ "$new_count" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
     echo "ignored-count=${ignored_count}" >> "$GITHUB_OUTPUT"
+    echo "below-threshold-count=${below_count}" >> "$GITHUB_OUTPUT"
   fi
 
   # Step 9: fail the check when new, non-ignored vulnerabilities are introduced.

--- a/golang/govulncheck/scripts/govulncheck-report.sh
+++ b/golang/govulncheck/scripts/govulncheck-report.sh
@@ -3,7 +3,7 @@
 # then write a GitHub job summary with the findings.
 #
 # Usage:
-#   govulncheck-report.sh <pr-vulns.json> <base-vulns.json>
+#   govulncheck-report.sh <pr-vulns.json> <base-vulns.json> [ignore-file]
 #
 # Environment variables (set automatically by GitHub Actions):
 #   GITHUB_STEP_SUMMARY — path to the job summary file (falls back to stdout)
@@ -13,6 +13,23 @@
 #   go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 -json ./... > /tmp/pr-vulns.json 2>/dev/null || true
 #   # Compare two scans:
 #   ./govulncheck-report.sh /tmp/pr-vulns.json /tmp/base-vulns.json
+#
+# Ignore file format (optional third argument, conventionally .govulncheck-ignore):
+#   One Go vulnerability ID per line. Blank lines are skipped. Everything after
+#   a '#' is a comment. A comment block directly above an entry — or a trailing
+#   comment on the entry line — is captured as that entry's reason and rendered
+#   in the job summary, so the "why" travels with the suppression.
+#
+#     # x/crypto/openpgp is unmaintained upstream and has no fix. We only
+#     # require the module transitively; nothing in our build imports it.
+#     GO-2026-5932
+#
+#     GO-2025-1234  # waiting on github.com/foo/bar#42
+#
+#   Ignored IDs never fail the check. They are still listed in the job summary
+#   so a suppression stays visible rather than disappearing. A malformed line is
+#   a hard error: a silently misparsed ignore file would weaken the gate without
+#   anyone noticing.
 #
 # Expected govulncheck JSON format (protocol v1.0.0):
 #   Stream of pretty-printed JSON objects, each with exactly one field populated:
@@ -75,6 +92,69 @@ count_lines() {
   else
     echo "$input" | grep -c .
   fi
+}
+
+# Parse an ignore file into TAB-separated "ID<TAB>reason" lines on stdout.
+# Returns non-zero (after reporting every bad line) if any entry is malformed.
+#
+# Interval expressions and alternation are avoided in the patterns below so the
+# parser behaves identically under mawk (the default awk on Ubuntu runners),
+# gawk, and BSD awk.
+parse_ignorelist() {
+  local ignore_file=$1
+  awk -v file="$ignore_file" '
+    # Tolerate CRLF files authored on Windows.
+    { sub(/\r$/, "") }
+
+    # A blank line ends the current comment block, so a comment paragraph
+    # separated from an entry by whitespace is not mistaken for its reason.
+    /^[ \t]*$/ { pending = ""; next }
+
+    # Whole-line comment: accumulate as the pending reason for the next entry.
+    /^[ \t]*#/ {
+      text = $0
+      sub(/^[ \t]*#[ \t]?/, "", text)
+      pending = (pending == "" ? text : pending " " text)
+      next
+    }
+
+    {
+      line = $0
+      reason = ""
+
+      # A trailing comment on the entry line wins over the block above it.
+      hash = index(line, "#")
+      if (hash > 0) {
+        reason = substr(line, hash + 1)
+        line = substr(line, 1, hash - 1)
+        sub(/^[ \t]+/, "", reason); sub(/[ \t]+$/, "", reason)
+      }
+      sub(/^[ \t]+/, "", line); sub(/[ \t]+$/, "", line)
+
+      if (line !~ /^GO-[0-9][0-9][0-9][0-9]-[0-9]+$/) {
+        printf("::error file=%s,line=%d::malformed ignore entry \"%s\" — expected a Go vulnerability ID such as GO-2026-5932, optionally followed by \"# reason\"\n", file, NR, line) > "/dev/stderr"
+        bad = 1
+        pending = ""
+        next
+      }
+
+      if (reason == "") reason = pending
+      if (reason == "") reason = "(no reason given)"
+      printf("%s\t%s\n", line, reason)
+      pending = ""
+    }
+
+    END { if (bad) exit 1 }
+  ' "$ignore_file"
+}
+
+# Remove ignored IDs from a newline-separated ID list.
+# Both inputs are sorted and unique, so comm -23 is a plain set difference.
+filter_ids() {
+  local ids=$1
+  local ignored=$2
+  [ -z "$ignored" ] && { echo "$ids"; return 0; }
+  comm -23 <(echo "$ids") <(echo "$ignored") | grep . || true
 }
 
 # Build a JSON lookup keyed by vuln ID: { "GO-...": { summary, module, fixed } }
@@ -146,6 +226,31 @@ vuln_table() {
   done <<< "$ids"
 }
 
+# Emit a markdown table for ignored vulns, carrying the reason from the
+# ignore file so reviewers can see the justification without opening it.
+# Input is the TAB-separated "ID<TAB>reason" list produced by parse_ignorelist,
+# already restricted to IDs that actually appear in this scan.
+ignored_table() {
+  local entries=$1
+  local details_file=$2
+  echo "| Vulnerability | Summary | Module | Reason ignored |"
+  echo "|---|---|---|---|"
+  local id reason row
+  while IFS=$'\t' read -r id reason; do
+    [ -n "$id" ] || continue
+    # Escape pipes so a reason containing '|' cannot break the table layout.
+    reason=${reason//|/\\|}
+    row=$(jq -r --arg id "$id" --arg reason "$reason" '
+      .[$id] // null |
+      if .
+      then "[\($id)](https://pkg.go.dev/vuln/\($id)) | \(.summary) | `\(.module)@\(.version)` | \($reason)"
+      else "[\($id)](https://pkg.go.dev/vuln/\($id)) | — | — | \($reason)"
+      end
+    ' "$details_file" 2>/dev/null || echo "[$id](https://pkg.go.dev/vuln/$id) | — | — | ${reason}")
+    echo "| ${row} |"
+  done <<< "$entries"
+}
+
 # ---------------------------------------------------------------------------
 # Diff: compute new / resolved / pre-existing vulnerability sets
 # ---------------------------------------------------------------------------
@@ -169,7 +274,8 @@ diff_vuln_ids() {
 
 # Render the full GitHub job summary. Reads global state set by main():
 #   NEW_IDS, RESOLVED_IDS, EXISTING_IDS — newline-separated vuln ID lists
-#   new_count, resolved_count, existing_count — integer counts
+#   IGNORED_ENTRIES — TAB-separated "ID<TAB>reason" lines for suppressed vulns
+#   new_count, resolved_count, existing_count, ignored_count — integer counts
 # Falls back to stdout when GITHUB_STEP_SUMMARY is unset (local testing).
 write_summary() {
   local details_file=$1
@@ -212,6 +318,19 @@ write_summary() {
       vuln_table "$EXISTING_IDS" "$details_file"
       echo ""
       echo "</details>"
+      echo ""
+    fi
+
+    if [ "$ignored_count" -gt 0 ]; then
+      echo "### :mute: Ignored vulnerabilities ($ignored_count)"
+      echo ""
+      echo "Suppressed by \`${IGNORE_FILE_PATH}\`. These do not block the PR."
+      echo ""
+      echo "<details><summary>Click to expand</summary>"
+      echo ""
+      ignored_table "$IGNORED_ENTRIES" "$details_file"
+      echo ""
+      echo "</details>"
     fi
   } >> "$summary_file"
 }
@@ -225,17 +344,25 @@ write_summary() {
 DETAILS_FILE=$(mktemp)
 trap 'rm -f "$DETAILS_FILE"' EXIT
 
+# Ignore-list state, declared here so write_summary can read it under `set -u`
+# even when no ignore file is in play.
+IGNORED_ENTRIES=""
+IGNORE_FILE_PATH=""
+
 # Algorithm:
 #   1. Validate the PR scan output format (warn if protocol changed).
 #   2. Extract vuln IDs from both scans → sorted, unique, newline-separated.
-#   3. Set-diff the two ID lists → new / resolved / pre-existing.
-#   4. Build a { id → details } JSON lookup for rendering.
-#   5. Render a GitHub job summary with markdown tables.
-#   6. Expose counts via GITHUB_OUTPUT for downstream workflow steps.
-#   7. Exit 1 if any new vulns were introduced; 0 otherwise.
+#   3. Parse the ignore file (if any) into IDs + reasons.
+#   4. Set-diff the two ID lists → new / resolved / pre-existing.
+#   5. Subtract ignored IDs from every bucket; report them separately.
+#   6. Build a { id → details } JSON lookup for rendering.
+#   7. Render a GitHub job summary with markdown tables.
+#   8. Expose counts via GITHUB_OUTPUT for downstream workflow steps.
+#   9. Exit 1 if any non-ignored new vulns were introduced; 0 otherwise.
 main() {
-  local pr_json="${1:?Usage: govulncheck-report.sh <pr-vulns.json> <base-vulns.json>}"
-  local base_json="${2:?Usage: govulncheck-report.sh <pr-vulns.json> <base-vulns.json>}"
+  local pr_json="${1:?Usage: govulncheck-report.sh <pr-vulns.json> <base-vulns.json> [ignore-file]}"
+  local base_json="${2:?Usage: govulncheck-report.sh <pr-vulns.json> <base-vulns.json> [ignore-file]}"
+  local ignore_file="${3:-}"
 
   if ! command -v jq &>/dev/null; then
     echo "::error::jq is required but not installed — use a GitHub-hosted runner or install jq"
@@ -248,37 +375,89 @@ main() {
   PR_IDS=$(extract_ids "$pr_json")
   BASE_IDS=$(extract_ids "$base_json")
 
-  # Step 3: compute set differences (populates NEW_IDS, RESOLVED_IDS, EXISTING_IDS).
+  # Step 3: parse the ignore file. It is read from the head tree, so a PR can
+  # add a suppression and have it apply to itself — required to unblock a PR at
+  # all. Gate that with CODEOWNERS on the ignore file if review is needed.
+  # A parse failure is fatal: continuing would silently apply a partial list.
+  IGNORE_FILE_PATH=$ignore_file
+  local ignore_entries=""
+  if [ -n "$ignore_file" ]; then
+    if [ ! -f "$ignore_file" ]; then
+      echo "::error::ignore file '${ignore_file}' not found"
+      exit 1
+    fi
+    if ! ignore_entries=$(parse_ignorelist "$ignore_file"); then
+      echo "::error::could not parse ignore file '${ignore_file}' — see the annotations above"
+      exit 1
+    fi
+  fi
+
+  # De-duplicate by ID (first entry wins, so the reason nearest the top of the
+  # file is the one shown), then sort so the IDs can be fed to comm as a set.
+  local ignored_ids=""
+  if [ -n "$ignore_entries" ]; then
+    local dupes
+    dupes=$(cut -f1 <<< "$ignore_entries" | sort | uniq -d | grep . || true)
+    if [ -n "$dupes" ]; then
+      echo "::warning::duplicate entries in ${ignore_file}: $(tr '\n' ' ' <<< "$dupes")"
+    fi
+    ignore_entries=$(awk -F'\t' '!seen[$1]++' <<< "$ignore_entries" | sort -t$'\t' -k1,1)
+    ignored_ids=$(cut -f1 <<< "$ignore_entries")
+  fi
+
+  # Step 4: compute set differences (populates NEW_IDS, RESOLVED_IDS, EXISTING_IDS).
   diff_vuln_ids "$PR_IDS" "$BASE_IDS"
+
+  # Step 5: an ignored ID must not land in any bucket that implies action. Only
+  # entries that actually matched this scan are reported as ignored; the rest
+  # are stale and flagged so the file does not accumulate dead suppressions.
+  if [ -n "$ignored_ids" ]; then
+    NEW_IDS=$(filter_ids "$NEW_IDS" "$ignored_ids")
+    RESOLVED_IDS=$(filter_ids "$RESOLVED_IDS" "$ignored_ids")
+    EXISTING_IDS=$(filter_ids "$EXISTING_IDS" "$ignored_ids")
+
+    # Keep only the entries whose ID actually appeared in this scan.
+    IGNORED_ENTRIES=$(awk -F'\t' 'NR==FNR { present[$0]=1; next } present[$1]' \
+      <(echo "$PR_IDS") <(echo "$ignore_entries") || true)
+
+    local stale stale_count
+    stale=$(comm -23 <(echo "$ignored_ids") <(echo "$PR_IDS") | grep . || true)
+    stale_count=$(count_lines "$stale")
+    if [ "$stale_count" -gt 0 ]; then
+      echo "::warning::${IGNORE_FILE_PATH} lists ${stale_count} $([ "$stale_count" -eq 1 ] && echo "vulnerability" || echo "vulnerabilities") not present in this scan — consider removing: $(tr '\n' ' ' <<< "$stale")"
+    fi
+  fi
 
   new_count=$(count_lines "$NEW_IDS")
   resolved_count=$(count_lines "$RESOLVED_IDS")
   existing_count=$(count_lines "$EXISTING_IDS")
+  ignored_count=$(count_lines "${IGNORED_ENTRIES:-}")
 
   # Emit an annotation visible in the PR checks summary.
   if [ "$new_count" -gt 0 ]; then
     echo "::error::${new_count} new $([ "$new_count" -eq 1 ] && echo "vulnerability" || echo "vulnerabilities") introduced — see job summary for details"
   fi
 
-  # Step 4: build the { id → details } lookup from the PR scan's JSON.
+  # Step 6: build the { id → details } lookup from the PR scan's JSON.
   # Only the PR scan is used here — it has the superset of findings we need
   # details for (new + pre-existing). Resolved vulns get details from the base
   # scan's OSV entries which are also present if the PR still references those
   # modules (even if the finding is gone).
   build_detail_lookup "$pr_json" > "$DETAILS_FILE"
 
-  # Step 5: write the GitHub job summary.
+  # Step 7: write the GitHub job summary.
   # write_summary reads the global counts and ID lists set above.
   write_summary "$DETAILS_FILE"
 
-  # Step 6: expose counts for downstream workflow steps (e.g., conditional notifications).
+  # Step 8: expose counts for downstream workflow steps (e.g., conditional notifications).
   # Gated on GITHUB_OUTPUT so the script still works when run locally.
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
     echo "new-count=${new_count}" >> "$GITHUB_OUTPUT"
     echo "has-new-vulns=$([ "$new_count" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+    echo "ignored-count=${ignored_count}" >> "$GITHUB_OUTPUT"
   fi
 
-  # Step 7: fail the check when new vulnerabilities are introduced.
+  # Step 9: fail the check when new, non-ignored vulnerabilities are introduced.
   if [ "$new_count" -gt 0 ]; then
     exit 1
   fi

--- a/golang/govulncheck/tests/fail-on-test.sh
+++ b/golang/govulncheck/tests/fail-on-test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Unit tests for the fail-on (reachability) threshold in govulncheck-report.sh.
+#
+# govulncheck reports a vulnerability at module, package, or symbol level. Only
+# symbol level means "your code calls this". These tests pin which levels block
+# at each threshold, that below-threshold findings are still reported, and how
+# the threshold interacts with the ignore list.
+#
+# Usage: bash golang/govulncheck/tests/fail-on-test.sh
+set -uo pipefail
+
+# >/dev/null: with CDPATH set, cd echoes the resolved directory.
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)/lib.sh"
+
+echo "govulncheck-report.sh fail-on threshold"
+
+MODULE_ONLY="$(scan GO-2026-5932)"                # in go.mod, package not imported
+IMPORTED="$(scan GO-2026-5932:package)"           # package imported, symbol not called
+CALLED="$(scan GO-2026-5932:symbol)"              # code calls the vulnerable symbol
+
+# ---------------------------------------------------------------------------
+# Default: module. Preserves the pre-existing behaviour of failing on anything.
+# ---------------------------------------------------------------------------
+
+run_report "$MODULE_ONLY" "$EMPTY_SCAN" "" "module"
+expect "module threshold: module-level vuln fails" 1 0 1
+expect_below "module threshold: nothing below it" 0
+
+run_report "$CALLED" "$EMPTY_SCAN" "" "module"
+expect "module threshold: called vuln fails" 1 0 1
+
+# Omitting fail-on entirely must behave exactly like 'module'.
+printf '%s\n' "$MODULE_ONLY" > "${WORK}/pr.json"
+printf '%s\n' "$EMPTY_SCAN"  > "${WORK}/base.json"
+GITHUB_OUTPUT="${WORK}/o.txt" GITHUB_STEP_SUMMARY="${WORK}/s.md" \
+  bash "$REPORT" "${WORK}/pr.json" "${WORK}/base.json" >/dev/null 2>&1
+expect_exit "omitted fail-on defaults to module" 1
+
+# ---------------------------------------------------------------------------
+# symbol: the motivating case. GO-2026-5932 is module-level only, so it stops
+# blocking, but a genuinely called vulnerability still does.
+# ---------------------------------------------------------------------------
+
+run_report "$MODULE_ONLY" "$EMPTY_SCAN" "" "symbol"
+expect "symbol threshold: module-level vuln passes" 0 0 0
+expect_below "symbol threshold: module-level vuln reported below" 1
+expect_in "below-threshold section rendered" "$RUN_SUMMARY" "Below the \`symbol\` threshold (1)"
+expect_in "below-threshold vuln still named" "$RUN_SUMMARY" "GO-2026-5932"
+expect_in "below-threshold wording explains why" "$RUN_SUMMARY" "does not call the vulnerable symbols"
+
+run_report "$IMPORTED" "$EMPTY_SCAN" "" "symbol"
+expect "symbol threshold: imported-but-uncalled passes" 0 0 0
+expect_below "symbol threshold: imported vuln reported below" 1
+
+run_report "$CALLED" "$EMPTY_SCAN" "" "symbol"
+expect "symbol threshold: called vuln still fails" 1 0 1
+expect_below "symbol threshold: called vuln not below" 0
+
+# ---------------------------------------------------------------------------
+# package: the middle setting.
+# ---------------------------------------------------------------------------
+
+run_report "$MODULE_ONLY" "$EMPTY_SCAN" "" "package"
+expect "package threshold: module-level vuln passes" 0 0 0
+expect_below "package threshold: module-level vuln reported below" 1
+
+run_report "$IMPORTED" "$EMPTY_SCAN" "" "package"
+expect "package threshold: imported vuln fails" 1 0 1
+
+run_report "$CALLED" "$EMPTY_SCAN" "" "package"
+expect "package threshold: called vuln fails" 1 0 1
+
+# ---------------------------------------------------------------------------
+# Level reduction: govulncheck emits module- and package-level findings
+# alongside the symbol-level one for the same ID. The highest level must win,
+# otherwise a called vulnerability would look unreachable and slip through.
+# ---------------------------------------------------------------------------
+
+MIXED="$(scan GO-2026-5932:symbol GO-2025-1234)"
+run_report "$MIXED" "$EMPTY_SCAN" "" "symbol"
+expect "mixed scan: only the called vuln fails" 1 0 1
+expect_below "mixed scan: the unreachable one is reported below" 1
+
+# ---------------------------------------------------------------------------
+# Interaction with the ignore list
+# ---------------------------------------------------------------------------
+
+IGNORE="$(write_ignore 'GO-2026-5932  # accepted risk
+')"
+
+# An ignored, called vulnerability is suppressed at any threshold.
+run_report "$CALLED" "$EMPTY_SCAN" "$IGNORE" "symbol"
+expect "ignore beats threshold for a called vuln" 0 1 0
+
+# An ignore entry covering a below-threshold finding is reported as ignored,
+# not listed twice, and must not be flagged stale just because the threshold
+# already excused it.
+run_report "$MODULE_ONLY" "$EMPTY_SCAN" "$IGNORE" "symbol"
+expect "ignored below-threshold vuln -> ignored bucket" 0 1 0
+expect_below "ignored vuln removed from below-threshold list" 0
+expect_not_in "not flagged as a stale ignore entry" "$RUN_LOG" "not present in this scan"
+
+# A vulnerability that is only pre-existing must not resurface as new when the
+# threshold changes what is counted on each side.
+run_report "$CALLED" "$CALLED" "" "symbol"
+expect "called vuln on both branches -> pre-existing" 0 0 0
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+run_report "$CALLED" "$EMPTY_SCAN" "" "reachable"
+expect_exit "unknown fail-on level -> hard error" 1
+expect_in "unknown level names the valid options" "$RUN_LOG" "expected one of: module, package, symbol"
+
+# An empty value (someone wiring `fail-on: ''` through a workflow variable)
+# falls back to the default rather than erroring.
+run_report "$MODULE_ONLY" "$EMPTY_SCAN" "" ""
+expect "empty fail-on falls back to module" 1 0 1
+
+finish_tests

--- a/golang/govulncheck/tests/ignorelist-test.sh
+++ b/golang/govulncheck/tests/ignorelist-test.sh
@@ -9,94 +9,8 @@
 # Usage: bash golang/govulncheck/tests/ignorelist-test.sh
 set -uo pipefail
 
-# >/dev/null: with CDPATH set, cd echoes the resolved directory and would
-# otherwise end up concatenated into SCRIPT_DIR.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-REPORT="${SCRIPT_DIR}/../scripts/govulncheck-report.sh"
-WORK="$(mktemp -d)"
-trap 'rm -rf "$WORK"' EXIT
-
-PASS=0 FAIL=0
-
-# ---------------------------------------------------------------------------
-# Fixtures: build govulncheck's v1 JSON stream (concatenated objects, not NDJSON)
-# ---------------------------------------------------------------------------
-
-# osv <id> <summary> — vulnerability metadata object.
-osv() {
-  jq -n --arg id "$1" --arg summary "$2" '{osv: {id: $id, summary: $summary}}'
-}
-
-# finding <id> — a module-level finding for that vulnerability.
-finding() {
-  jq -n --arg id "$1" \
-    '{finding: {osv: $id, fixed_version: "", trace: [{module: "example.com/dep", version: "v1.0.0"}]}}'
-}
-
-# scan <id>... — a full scan document reporting each id once.
-scan() {
-  jq -n '{config: {protocol_version: "v1.0.0"}}'
-  local id
-  for id in "$@"; do
-    osv "$id" "summary for ${id}"
-    finding "$id"
-  done
-}
-
-EMPTY_SCAN="$(jq -n '{config: {protocol_version: "v1.0.0"}}')"
-
-# ---------------------------------------------------------------------------
-# Test harness
-# ---------------------------------------------------------------------------
-
-# run_report <pr-json> <base-json> <ignore-file-or-empty>
-# Populates RUN_EXIT, RUN_NEW, RUN_IGNORED, RUN_SUMMARY, RUN_LOG.
-run_report() {
-  printf '%s\n' "$1" > "${WORK}/pr.json"
-  printf '%s\n' "$2" > "${WORK}/base.json"
-
-  RUN_SUMMARY="${WORK}/summary.md"
-  RUN_LOG="${WORK}/log.txt"
-  local outputs="${WORK}/outputs.txt"
-  : > "$RUN_SUMMARY"
-  : > "$outputs"
-
-  GITHUB_OUTPUT="$outputs" GITHUB_STEP_SUMMARY="$RUN_SUMMARY" \
-    bash "$REPORT" "${WORK}/pr.json" "${WORK}/base.json" "$3" > "$RUN_LOG" 2>&1
-  RUN_EXIT=$?
-
-  RUN_NEW=$(sed -n 's/^new-count=//p' "$outputs");         RUN_NEW=${RUN_NEW:-MISSING}
-  RUN_IGNORED=$(sed -n 's/^ignored-count=//p' "$outputs"); RUN_IGNORED=${RUN_IGNORED:-MISSING}
-}
-
-ok()  { echo "  [PASS] $1"; PASS=$((PASS + 1)); }
-bad() { echo "  [FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
-
-# expect <name> <want-new> <want-ignored> <want-exit>  (call after run_report)
-expect() {
-  local name=$1 want_new=$2 want_ignored=$3 want_exit=$4
-  if [ "$RUN_NEW" = "$want_new" ] && [ "$RUN_IGNORED" = "$want_ignored" ] && [ "$RUN_EXIT" = "$want_exit" ]; then
-    ok "$name"
-  else
-    bad "$name" "got new=${RUN_NEW} ignored=${RUN_IGNORED} exit=${RUN_EXIT}, want new=${want_new} ignored=${want_ignored} exit=${want_exit}"
-  fi
-}
-
-# expect_in <name> <file> <fixed-string>
-expect_in() {
-  if grep -qF "$3" "$2"; then ok "$1"; else bad "$1" "missing \"$3\" in $(basename "$2")"; fi
-}
-
-# expect_not_in <name> <file> <fixed-string>
-expect_not_in() {
-  if grep -qF "$3" "$2"; then bad "$1" "unexpected \"$3\" in $(basename "$2")"; else ok "$1"; fi
-}
-
-# write_ignore <content> — write the ignore file, return its path on stdout.
-write_ignore() {
-  printf '%s' "$1" > "${WORK}/.govulncheck-ignore"
-  echo "${WORK}/.govulncheck-ignore"
-}
+# >/dev/null: with CDPATH set, cd echoes the resolved directory.
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)/lib.sh"
 
 echo "govulncheck-report.sh ignore list"
 
@@ -193,11 +107,11 @@ IGNORE="$(write_ignore 'GO-2026-5932
 CVE-2026-1111
 ')"
 run_report "$ONE_VULN" "$EMPTY_SCAN" "$IGNORE"
-if [ "$RUN_EXIT" = "1" ]; then ok "malformed entry -> hard error"; else bad "malformed entry -> hard error" "exit=${RUN_EXIT}"; fi
+expect_exit "malformed entry -> hard error" 1
 expect_in "malformed entry annotated with line number" "$RUN_LOG" "line=2::malformed ignore entry"
 
 run_report "$ONE_VULN" "$EMPTY_SCAN" "${WORK}/does-not-exist"
-if [ "$RUN_EXIT" = "1" ]; then ok "missing explicit ignore file -> error"; else bad "missing explicit ignore file -> error" "exit=${RUN_EXIT}"; fi
+expect_exit "missing explicit ignore file -> error" 1
 expect_in "missing file reported" "$RUN_LOG" "not found"
 
 # A suppression that no longer matches anything should be surfaced, not silently
@@ -216,6 +130,4 @@ expect "duplicate entries counted once" 0 1 0
 expect_in "duplicate entries warned about" "$RUN_LOG" "duplicate entries in"
 expect_in "first duplicate's reason wins" "$RUN_SUMMARY" "first"
 
-echo ""
-echo "${PASS} passed, ${FAIL} failed"
-[ "$FAIL" -eq 0 ]
+finish_tests

--- a/golang/govulncheck/tests/ignorelist-test.sh
+++ b/golang/govulncheck/tests/ignorelist-test.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Unit tests for the ignore-list handling in govulncheck-report.sh.
+#
+# These cover the parser (comments, reasons, malformed input) and the effect an
+# ignore entry has on the new/pre-existing/ignored buckets and the exit code.
+# Everything is driven by the scan JSON, so the tests craft that JSON directly —
+# no govulncheck install, Go toolchain, or network needed.
+#
+# Usage: bash golang/govulncheck/tests/ignorelist-test.sh
+set -uo pipefail
+
+# >/dev/null: with CDPATH set, cd echoes the resolved directory and would
+# otherwise end up concatenated into SCRIPT_DIR.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+REPORT="${SCRIPT_DIR}/../scripts/govulncheck-report.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0 FAIL=0
+
+# ---------------------------------------------------------------------------
+# Fixtures: build govulncheck's v1 JSON stream (concatenated objects, not NDJSON)
+# ---------------------------------------------------------------------------
+
+# osv <id> <summary> — vulnerability metadata object.
+osv() {
+  jq -n --arg id "$1" --arg summary "$2" '{osv: {id: $id, summary: $summary}}'
+}
+
+# finding <id> — a module-level finding for that vulnerability.
+finding() {
+  jq -n --arg id "$1" \
+    '{finding: {osv: $id, fixed_version: "", trace: [{module: "example.com/dep", version: "v1.0.0"}]}}'
+}
+
+# scan <id>... — a full scan document reporting each id once.
+scan() {
+  jq -n '{config: {protocol_version: "v1.0.0"}}'
+  local id
+  for id in "$@"; do
+    osv "$id" "summary for ${id}"
+    finding "$id"
+  done
+}
+
+EMPTY_SCAN="$(jq -n '{config: {protocol_version: "v1.0.0"}}')"
+
+# ---------------------------------------------------------------------------
+# Test harness
+# ---------------------------------------------------------------------------
+
+# run_report <pr-json> <base-json> <ignore-file-or-empty>
+# Populates RUN_EXIT, RUN_NEW, RUN_IGNORED, RUN_SUMMARY, RUN_LOG.
+run_report() {
+  printf '%s\n' "$1" > "${WORK}/pr.json"
+  printf '%s\n' "$2" > "${WORK}/base.json"
+
+  RUN_SUMMARY="${WORK}/summary.md"
+  RUN_LOG="${WORK}/log.txt"
+  local outputs="${WORK}/outputs.txt"
+  : > "$RUN_SUMMARY"
+  : > "$outputs"
+
+  GITHUB_OUTPUT="$outputs" GITHUB_STEP_SUMMARY="$RUN_SUMMARY" \
+    bash "$REPORT" "${WORK}/pr.json" "${WORK}/base.json" "$3" > "$RUN_LOG" 2>&1
+  RUN_EXIT=$?
+
+  RUN_NEW=$(sed -n 's/^new-count=//p' "$outputs");         RUN_NEW=${RUN_NEW:-MISSING}
+  RUN_IGNORED=$(sed -n 's/^ignored-count=//p' "$outputs"); RUN_IGNORED=${RUN_IGNORED:-MISSING}
+}
+
+ok()  { echo "  [PASS] $1"; PASS=$((PASS + 1)); }
+bad() { echo "  [FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+# expect <name> <want-new> <want-ignored> <want-exit>  (call after run_report)
+expect() {
+  local name=$1 want_new=$2 want_ignored=$3 want_exit=$4
+  if [ "$RUN_NEW" = "$want_new" ] && [ "$RUN_IGNORED" = "$want_ignored" ] && [ "$RUN_EXIT" = "$want_exit" ]; then
+    ok "$name"
+  else
+    bad "$name" "got new=${RUN_NEW} ignored=${RUN_IGNORED} exit=${RUN_EXIT}, want new=${want_new} ignored=${want_ignored} exit=${want_exit}"
+  fi
+}
+
+# expect_in <name> <file> <fixed-string>
+expect_in() {
+  if grep -qF "$3" "$2"; then ok "$1"; else bad "$1" "missing \"$3\" in $(basename "$2")"; fi
+}
+
+# expect_not_in <name> <file> <fixed-string>
+expect_not_in() {
+  if grep -qF "$3" "$2"; then bad "$1" "unexpected \"$3\" in $(basename "$2")"; else ok "$1"; fi
+}
+
+# write_ignore <content> — write the ignore file, return its path on stdout.
+write_ignore() {
+  printf '%s' "$1" > "${WORK}/.govulncheck-ignore"
+  echo "${WORK}/.govulncheck-ignore"
+}
+
+echo "govulncheck-report.sh ignore list"
+
+# ---------------------------------------------------------------------------
+# Baseline: no ignore file
+# ---------------------------------------------------------------------------
+
+ONE_VULN="$(scan GO-2026-5932)"
+TWO_VULNS="$(scan GO-2026-5932 GO-2025-1234)"
+
+run_report "$ONE_VULN" "$EMPTY_SCAN" ""
+expect "no ignore file -> vuln still fails" 1 0 1
+
+# ---------------------------------------------------------------------------
+# Suppression
+# ---------------------------------------------------------------------------
+
+IGNORE="$(write_ignore 'GO-2026-5932
+')"
+run_report "$ONE_VULN" "$EMPTY_SCAN" "$IGNORE"
+expect "ignored new vuln -> passes" 0 1 0
+expect_in "ignored vuln appears in summary" "$RUN_SUMMARY" "Ignored vulnerabilities (1)"
+expect_not_in "ignored vuln absent from new section" "$RUN_SUMMARY" "New vulnerabilities"
+
+run_report "$TWO_VULNS" "$EMPTY_SCAN" "$IGNORE"
+expect "partial ignore -> remaining vuln still fails" 1 1 1
+
+# A pre-existing (present on both branches) vuln moves to the ignored bucket.
+run_report "$ONE_VULN" "$ONE_VULN" "$IGNORE"
+expect "ignored pre-existing vuln -> ignored bucket" 0 1 0
+expect_not_in "not double-reported as pre-existing" "$RUN_SUMMARY" "Pre-existing vulnerabilities"
+
+# ---------------------------------------------------------------------------
+# Comments and reasons
+# ---------------------------------------------------------------------------
+
+IGNORE="$(write_ignore '# This whole file is comments.
+
+# So is this paragraph.
+')"
+run_report "$ONE_VULN" "$EMPTY_SCAN" "$IGNORE"
+expect "comment-only file -> no suppression" 1 0 1
+
+IGNORE="$(write_ignore 'GO-2026-5932  # waiting on upstream fix
+')"
+run_report "$ONE_VULN" "$EMPTY_SCAN" "$IGNORE"
+expect "trailing-comment entry parses" 0 1 0
+expect_in "trailing comment used as reason" "$RUN_SUMMARY" "waiting on upstream fix"
+
+IGNORE="$(write_ignore '# x/crypto/openpgp is unmaintained.
+# Nothing in our build imports it.
+GO-2026-5932
+')"
+run_report "$ONE_VULN" "$EMPTY_SCAN" "$IGNORE"
+expect "preceding comment block parses" 0 1 0
+expect_in "comment block joined into reason" "$RUN_SUMMARY" "x/crypto/openpgp is unmaintained. Nothing in our build imports it."
+
+# A blank line detaches a comment paragraph from the entry below it, so an
+# unrelated header comment is not misattributed as a justification.
+IGNORE="$(write_ignore '# Header for the file, not a reason.
+
+GO-2026-5932
+')"
+run_report "$ONE_VULN" "$EMPTY_SCAN" "$IGNORE"
+expect "blank line detaches comment block" 0 1 0
+expect_in "undocumented entry marked as such" "$RUN_SUMMARY" "(no reason given)"
+expect_not_in "detached comment not used as reason" "$RUN_SUMMARY" "Header for the file"
+
+# Trailing comment wins over the block above it.
+IGNORE="$(write_ignore '# block reason
+GO-2026-5932 # inline reason
+')"
+run_report "$ONE_VULN" "$EMPTY_SCAN" "$IGNORE"
+expect_in "inline reason overrides block reason" "$RUN_SUMMARY" "inline reason"
+expect_not_in "block reason dropped when inline present" "$RUN_SUMMARY" "block reason"
+
+# A pipe in a reason must not break the markdown table.
+IGNORE="$(write_ignore 'GO-2026-5932 # accepted | see SEC-1234
+')"
+run_report "$ONE_VULN" "$EMPTY_SCAN" "$IGNORE"
+expect "reason containing a pipe" 0 1 0
+expect_in "pipe escaped in table cell" "$RUN_SUMMARY" 'accepted \| see SEC-1234'
+
+# CRLF line endings (file authored on Windows) must still parse.
+printf 'GO-2026-5932  # windows\r\n' > "${WORK}/.govulncheck-ignore"
+run_report "$ONE_VULN" "$EMPTY_SCAN" "${WORK}/.govulncheck-ignore"
+expect "CRLF ignore file parses" 0 1 0
+
+# ---------------------------------------------------------------------------
+# Error and hygiene cases
+# ---------------------------------------------------------------------------
+
+IGNORE="$(write_ignore 'GO-2026-5932
+CVE-2026-1111
+')"
+run_report "$ONE_VULN" "$EMPTY_SCAN" "$IGNORE"
+if [ "$RUN_EXIT" = "1" ]; then ok "malformed entry -> hard error"; else bad "malformed entry -> hard error" "exit=${RUN_EXIT}"; fi
+expect_in "malformed entry annotated with line number" "$RUN_LOG" "line=2::malformed ignore entry"
+
+run_report "$ONE_VULN" "$EMPTY_SCAN" "${WORK}/does-not-exist"
+if [ "$RUN_EXIT" = "1" ]; then ok "missing explicit ignore file -> error"; else bad "missing explicit ignore file -> error" "exit=${RUN_EXIT}"; fi
+expect_in "missing file reported" "$RUN_LOG" "not found"
+
+# A suppression that no longer matches anything should be surfaced, not silently
+# carried forever — but it must not fail the build on its own.
+IGNORE="$(write_ignore 'GO-2020-0001  # long since resolved
+')"
+run_report "$ONE_VULN" "$ONE_VULN" "$IGNORE"
+expect "stale entry does not suppress or fail" 0 0 0
+expect_in "stale entry warned about" "$RUN_LOG" "not present in this scan"
+
+IGNORE="$(write_ignore 'GO-2026-5932 # first
+GO-2026-5932 # second
+')"
+run_report "$ONE_VULN" "$EMPTY_SCAN" "$IGNORE"
+expect "duplicate entries counted once" 0 1 0
+expect_in "duplicate entries warned about" "$RUN_LOG" "duplicate entries in"
+expect_in "first duplicate's reason wins" "$RUN_SUMMARY" "first"
+
+echo ""
+echo "${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ]

--- a/golang/govulncheck/tests/lib.sh
+++ b/golang/govulncheck/tests/lib.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Shared fixtures and assertions for govulncheck-report.sh tests.
+#
+# Everything here is driven by crafted scan JSON, so the tests need no
+# govulncheck install, Go toolchain, or network. Source this from a test file:
+#
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+#
+# Sourcing sets up SCRIPT_DIR, REPORT, WORK (a temp dir removed on exit), and
+# the PASS/FAIL counters that finish_tests reports on.
+
+# >/dev/null: with CDPATH set, cd echoes the resolved directory and would
+# otherwise end up concatenated into SCRIPT_DIR.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+REPORT="${SCRIPT_DIR}/../scripts/govulncheck-report.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0 FAIL=0
+
+# ---------------------------------------------------------------------------
+# Fixtures: build govulncheck's v1 JSON stream (concatenated objects, not NDJSON)
+# ---------------------------------------------------------------------------
+
+# osv <id> <summary> — vulnerability metadata object.
+osv() {
+  jq -n --arg id "$1" --arg summary "$2" '{osv: {id: $id, summary: $summary}}'
+}
+
+# finding <id> <level> — one finding object at module, package, or symbol level.
+#
+# The level is encoded by how much of trace[0] is populated, mirroring
+# golang.org/x/vuln/internal/govulncheck: module+version only for module level,
+# plus package for package level, plus function (and a caller frame) for symbol
+# level. Frames run from the vulnerable symbol outward to the entry point.
+finding() {
+  local id=$1 level=$2
+  case "$level" in
+    module)
+      jq -n --arg id "$id" '{finding: {osv: $id, fixed_version: "", trace: [
+        {module: "example.com/dep", version: "v1.0.0"}]}}' ;;
+    package)
+      jq -n --arg id "$id" '{finding: {osv: $id, fixed_version: "", trace: [
+        {module: "example.com/dep", version: "v1.0.0", package: "example.com/dep/vuln"}]}}' ;;
+    symbol)
+      jq -n --arg id "$id" '{finding: {osv: $id, fixed_version: "", trace: [
+        {module: "example.com/dep", version: "v1.0.0", package: "example.com/dep/vuln", function: "Vulnerable"},
+        {module: "example.com/app", version: "", package: "example.com/app", function: "main"}]}}' ;;
+    *)
+      echo "lib.sh: unknown finding level '${level}'" >&2; return 1 ;;
+  esac
+}
+
+# scan <id>[:<level>]... — a full scan document. Level defaults to module.
+#
+# Emits the cascade govulncheck actually produces: a symbol-level vulnerability
+# also yields module- and package-level findings for the same ID. That is what
+# makes "reduce each ID to its highest level" the correct reading, so the
+# fixtures have to reproduce it.
+scan() {
+  jq -n '{config: {protocol_version: "v1.0.0"}}'
+  local spec id level
+  for spec in "$@"; do
+    id=${spec%%:*}
+    level=${spec#*:}
+    [ "$level" = "$id" ] && level=module
+    osv "$id" "summary for ${id}"
+    finding "$id" module
+    case "$level" in
+      package) finding "$id" package ;;
+      symbol)  finding "$id" package; finding "$id" symbol ;;
+    esac
+  done
+}
+
+EMPTY_SCAN="$(jq -n '{config: {protocol_version: "v1.0.0"}}')"
+
+# ---------------------------------------------------------------------------
+# Test harness
+# ---------------------------------------------------------------------------
+
+# run_report <pr-json> <base-json> <ignore-file-or-empty> [fail-on]
+# Populates RUN_EXIT, RUN_NEW, RUN_IGNORED, RUN_BELOW, RUN_SUMMARY, RUN_LOG.
+run_report() {
+  printf '%s\n' "$1" > "${WORK}/pr.json"
+  printf '%s\n' "$2" > "${WORK}/base.json"
+
+  RUN_SUMMARY="${WORK}/summary.md"
+  RUN_LOG="${WORK}/log.txt"
+  local outputs="${WORK}/outputs.txt"
+  : > "$RUN_SUMMARY"
+  : > "$outputs"
+
+  GITHUB_OUTPUT="$outputs" GITHUB_STEP_SUMMARY="$RUN_SUMMARY" \
+    bash "$REPORT" "${WORK}/pr.json" "${WORK}/base.json" "$3" "${4:-module}" > "$RUN_LOG" 2>&1
+  RUN_EXIT=$?
+
+  RUN_NEW=$(sed -n 's/^new-count=//p' "$outputs");              RUN_NEW=${RUN_NEW:-MISSING}
+  RUN_IGNORED=$(sed -n 's/^ignored-count=//p' "$outputs");      RUN_IGNORED=${RUN_IGNORED:-MISSING}
+  RUN_BELOW=$(sed -n 's/^below-threshold-count=//p' "$outputs"); RUN_BELOW=${RUN_BELOW:-MISSING}
+}
+
+ok()  { echo "  [PASS] $1"; PASS=$((PASS + 1)); }
+bad() { echo "  [FAIL] $1: $2"; FAIL=$((FAIL + 1)); }
+
+# expect <name> <want-new> <want-ignored> <want-exit>  (call after run_report)
+expect() {
+  local name=$1 want_new=$2 want_ignored=$3 want_exit=$4
+  if [ "$RUN_NEW" = "$want_new" ] && [ "$RUN_IGNORED" = "$want_ignored" ] && [ "$RUN_EXIT" = "$want_exit" ]; then
+    ok "$name"
+  else
+    bad "$name" "got new=${RUN_NEW} ignored=${RUN_IGNORED} exit=${RUN_EXIT}, want new=${want_new} ignored=${want_ignored} exit=${want_exit}"
+  fi
+}
+
+# expect_below <name> <want-below-threshold-count>
+expect_below() {
+  if [ "$RUN_BELOW" = "$2" ]; then ok "$1"; else bad "$1" "got below=${RUN_BELOW}, want ${2}"; fi
+}
+
+# expect_exit <name> <want-exit>
+expect_exit() {
+  if [ "$RUN_EXIT" = "$2" ]; then ok "$1"; else bad "$1" "got exit=${RUN_EXIT}, want ${2}"; fi
+}
+
+# expect_in <name> <file> <fixed-string>
+expect_in() {
+  if grep -qF "$3" "$2"; then ok "$1"; else bad "$1" "missing \"$3\" in $(basename "$2")"; fi
+}
+
+# expect_not_in <name> <file> <fixed-string>
+expect_not_in() {
+  if grep -qF "$3" "$2"; then bad "$1" "unexpected \"$3\" in $(basename "$2")"; else ok "$1"; fi
+}
+
+# write_ignore <content> — write the ignore file, return its path on stdout.
+write_ignore() {
+  printf '%s' "$1" > "${WORK}/.govulncheck-ignore"
+  echo "${WORK}/.govulncheck-ignore"
+}
+
+# finish_tests — print the tally and set the exit status.
+finish_tests() {
+  echo ""
+  echo "${PASS} passed, ${FAIL} failed"
+  [ "$FAIL" -eq 0 ]
+}


### PR DESCRIPTION
Two related escape hatches for findings the action currently has no answer for. Default behavior is unchanged; both are opt-in.

## Problem

The motivating case is [GO-2026-5932](https://pkg.go.dev/vuln/GO-2026-5932). `golang.org/x/crypto/openpgp` is unmaintained upstream ([go.dev/issue/44226](https://go.dev/issue/44226)) and the advisory covers *all versions*, so there is no fixed version and no dependency bump resolves it. Any repo that transitively requires `golang.org/x/crypto` trips it on the PR that introduces or bumps that dependency.

Two things make it unfixable today:

1. govulncheck has no ignore mechanism ([golang/go#61211](https://github.com/golang/go/issues/61211), open since 2023, `vuln/unplanned`), and neither does this action.
2. `extract_ids` counts every finding in the JSON stream regardless of scan level. A module-level finding that govulncheck itself reports as *"your code doesn't appear to call these"* blocks a PR exactly as hard as a symbol-level finding in a hot path.

## 1. `fail-on` — gate on reachability

govulncheck reports at three levels, encoded by how much of `trace[0]` is populated:

| Level | Meaning | govulncheck's own wording |
|---|---|---|
| `module` | Module is in the build graph | "in modules you require... your code doesn't appear to call these" |
| `package` | Vulnerable package is imported | "in packages you import" |
| `symbol` | Your code calls the vulnerable symbol | "Your code is affected by N vulnerabilities" |

```yaml
- uses: temporalio/public-actions/golang/govulncheck@main
  with:
    fail-on: symbol
```

One vulnerability produces findings at several levels at once, so each ID is reduced to its **highest** level before the threshold applies. Without that, a called vulnerability would also match its own module-level finding and could read as unreachable.

Findings below the threshold aren't dropped — they get their own job-summary section so the exposure stays visible, they just don't block.

For most repos hitting GO-2026-5932, `fail-on: symbol` resolves it with nothing to maintain per-vulnerability.

## 2. `.govulncheck-ignore` — accept a specific risk

For findings that *are* reachable but accepted:

```
# golang.org/x/crypto/openpgp is unmaintained upstream with no fixed version.
GO-2026-5932

GO-2025-1234  # reachable but low risk; tracked in SEC-1234
```

A trailing comment, or the comment block directly above an entry, becomes that entry's reason and is rendered in the job summary, so reviewers see the justification without opening the file. A blank line detaches a comment block from the entry below it, so a file header isn't misread as a justification.

Ignored IDs are removed from the new/resolved/pre-existing buckets and reported in their own section. An explicit ignore wins over the `fail-on` classification, so an ignored finding shows with its reason rather than as a bare below-threshold listing.

## Guardrails

This is a security gate, so the failure modes lean loud:

- **Malformed ignore line is a hard error.** A silently misparsed ignore file would weaken the check with no signal.
- **An explicitly configured `ignore-file` that doesn't exist is an error.** Only the conventional default may be absent, so a typo'd path can't quietly disable nothing.
- **An unrecognized `fail-on` value is an error**, rather than falling back to some threshold nobody intended.
- **Ignore entries matching nothing emit a warning**, so stale suppressions surface instead of accumulating.
- **Default `fail-on` stays `module`.** Loosening a shared security gate should be a deliberate per-repo decision, not something that arrives with an action bump.
- **The ignore file is read from the head tree**, so a PR can add an entry and unblock itself. Necessary (otherwise a suppression could never land), which makes the file itself the boundary — documented in the README as a `CODEOWNERS` hook.

Worth an explicit call from @temporalio/security: `fail-on: symbol` is the loosest setting. A vulnerability becomes blocking only once something calls it, and the analysis is static, so it can miss reflection- and codegen-driven call paths. Documented in the README under Reachability.

## Tests

Pure bash + jq over crafted scan JSON. No govulncheck install, Go toolchain, or network. Follows the existing opengrep test pattern; shared fixtures in `tests/lib.sh`, which reproduces the finding cascade govulncheck actually emits.

```
$ bash golang/govulncheck/tests/ignorelist-test.sh
29 passed, 0 failed

$ bash golang/govulncheck/tests/fail-on-test.sh
27 passed, 0 failed
```

Wired into CI on `ubuntu-latest`, which also exercises the ignore-file parser under mawk — it's written to the common subset of mawk, gawk, and BSD awk.

## Notes for reviewers

- No behavior change for any existing caller: no ignore file, and `fail-on` defaults to today's semantics.
- New outputs: `ignored-count`, `below-threshold-count`.
- Reviewable as two commits, one per feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)